### PR TITLE
Add NPE check to property for MapGetExecutor

### DIFF
--- a/src/main/java/org/apache/commons/jexl2/internal/MapGetExecutor.java
+++ b/src/main/java/org/apache/commons/jexl2/internal/MapGetExecutor.java
@@ -64,7 +64,7 @@ public final class MapGetExecutor extends AbstractExecutor.Get {
     public Object tryExecute(final Object obj, Object key) {
         if (obj != null &&  method != null
             && objectClass.equals(obj.getClass())
-            && (key == null || property.getClass().equals(key.getClass()))) {
+            && (key == null || property == null || property.getClass().equals(key.getClass()))) {
             @SuppressWarnings("unchecked") // ctor only allows Map instances - see discover() method
             final Map<Object,?> map = (Map<Object, ?>) obj;
             return map.get(key);


### PR DESCRIPTION
When the MapGetExecutor is init by the key null, the property of MapGetExecutor will be null. 
If the MapGetExecutor is cached and the key is changed (like map[index]), there will throw an NPE.
I think the intention for the condition is to compare the class compatibility, so I add the NPE check here.
