### PR TITLE
lambda syntax enhancements

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
@@ -675,9 +675,18 @@ public class Debugger extends ParserVisitor implements JexlInfo.Detail {
     protected Object visit(ASTJexlScript node, Object data) {
         // if lambda, produce parameters
         if (node instanceof ASTJexlLambda) {
+            boolean expr = false;
+
+            if (node.jjtGetNumChildren() == 1) {
+               JexlNode child = node.jjtGetChild(0);
+
+               if (!(child instanceof ASTBlock))
+                   expr = true;
+            }
+
             JexlNode parent = node.jjtGetParent();
             // use lambda syntax if not assigned
-            boolean named = parent instanceof ASTAssignment;
+            boolean named = parent instanceof ASTAssignment && !expr;
             if (named) {
                 builder.append("function");
             }
@@ -701,16 +710,6 @@ public class Debugger extends ParserVisitor implements JexlInfo.Detail {
             if (named) {
                 builder.append(' ');
             } else {
-
-                boolean expr = false;
-
-                if (node.jjtGetNumChildren() == 1) {
-                   JexlNode child = node.jjtGetChild(0);
-
-                   if (!(child instanceof ASTBlock))
-                       expr = true;
-                } 
-
                 if (expr) {
                     builder.append("=>");
                 } else {

--- a/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
@@ -681,8 +681,12 @@ public class Debugger extends ParserVisitor implements JexlInfo.Detail {
             if (named) {
                 builder.append("function");
             }
-            builder.append('(');
+
             String[] params = node.getParameters();
+
+            if (named || params == null || params.length != 1) 
+                builder.append('(');
+
             if (params != null && params.length > 0) {
                 builder.append(visitParameter(params[0], data));
                 for (int p = 1; p < params.length; ++p) {
@@ -690,11 +694,28 @@ public class Debugger extends ParserVisitor implements JexlInfo.Detail {
                     builder.append(visitParameter(params[p], data));
                 }
             }
-            builder.append(')');
+
+            if (named || params == null || params.length != 1) 
+                builder.append(')');
+
             if (named) {
                 builder.append(' ');
             } else {
-                builder.append("->");
+
+                boolean expr = false;
+
+                if (node.jjtGetNumChildren() == 1) {
+                   JexlNode child = node.jjtGetChild(0);
+
+                   if (!(child instanceof ASTBlock))
+                       expr = true;
+                } 
+
+                if (expr) {
+                    builder.append("=>");
+                } else {
+                    builder.append("->");
+                }
             }
             // we will need a block...
         }

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -131,6 +131,7 @@ TOKEN_MGR_DECLS : {
     | < RETURN : "return" >
     | < FUNCTION : "function" >
     | < LAMBDA : "->" >
+    | < LAMBDAE : "=>" >
     | < BREAK : "break" >
     | < CONTINUE : "continue" >
     | < PRAGMA : "#pragma" >
@@ -458,61 +459,71 @@ void AssignmentExpression() #void : {}
 void ConditionalExpression() #void : {}
 {
   ConditionalOrExpression()
-  (
+  ( LOOKAHEAD(2) (
     <QMARK> Expression() <COLON> Expression() #TernaryNode(3)
   |
     <ELVIS> Expression() #TernaryNode(2)
   |
     <NULLP> Expression() #NullpNode(2)
-  )?
+  ) )?
 }
 
 void ConditionalOrExpression() #void : {}
 {
   ConditionalAndExpression()
-  ( <OR> ConditionalAndExpression() #OrNode(2) )*
+  ( LOOKAHEAD(2) (
+     <OR> ConditionalAndExpression() #OrNode(2) 
+  ) )*
 }
 
 void ConditionalAndExpression() #void : {}
 {
   InclusiveOrExpression()
-  ( <AND> InclusiveOrExpression() #AndNode(2) )*
+  ( LOOKAHEAD(2) (
+     <AND> InclusiveOrExpression() #AndNode(2) 
+  ) )*
 }
 
 void InclusiveOrExpression() #void : {}
 {
   ExclusiveOrExpression()
-  ( <or> ExclusiveOrExpression() #BitwiseOrNode(2) )*
+  ( LOOKAHEAD(2) (
+     <or> ExclusiveOrExpression() #BitwiseOrNode(2) 
+  ) )*
 }
 
 void ExclusiveOrExpression() #void : {}
 {
   AndExpression()
-  ( <xor> AndExpression() #BitwiseXorNode(2) )*
+  ( LOOKAHEAD(2) (
+     <xor> AndExpression() #BitwiseXorNode(2) 
+  ) )*
 }
 
 void AndExpression() #void : {}
 {
   EqualityExpression()
-  ( <and> EqualityExpression() #BitwiseAndNode(2) )*
+  ( LOOKAHEAD(2) (
+     <and> EqualityExpression() #BitwiseAndNode(2) 
+  ) )*
 }
 
 void EqualityExpression() #void : {}
 {
   RelationalExpression()
-  (
+  ( LOOKAHEAD(2) (
      <eq> RelationalExpression() #EQNode(2)
    |
      <ne> RelationalExpression() #NENode(2)
    |
      <range> RelationalExpression() #RangeNode(2) // range
-  )?
+  ) )?
 }
 
 void RelationalExpression() #void : {}
 {
   AdditiveExpression()
-  (
+  ( LOOKAHEAD(2) (
     <lt> AdditiveExpression() #LTNode(2)
    |
     <gt> AdditiveExpression() #GTNode(2)
@@ -532,7 +543,7 @@ void RelationalExpression() #void : {}
     <eeq> AdditiveExpression() #EWNode(2) // ends with
    |
     <ene> AdditiveExpression() #NEWNode(2) // not ends with
-  )?
+  ) )?
 }
 
 /***************************************
@@ -552,13 +563,13 @@ void AdditiveExpression() #void : {}
 void MultiplicativeExpression() #void : {}
 {
   UnaryExpression()
-  (
+  ( LOOKAHEAD(2) (
     <mult> UnaryExpression() #MulNode(2)
   |
     <div> UnaryExpression() #DivNode(2)
   |
     <mod> UnaryExpression() #ModNode(2)
-  )*
+  ) )*
 }
 
 void UnaryExpression() #void : {}
@@ -780,9 +791,9 @@ void LambdaLookahead() #void() : {}
 {
   <FUNCTION> Parameters()
   |
-  Parameters() <LAMBDA>
+  Parameters() ( <LAMBDA> | <LAMBDAE> )
   |
-  Parameter() <LAMBDA>
+  Parameter() ( <LAMBDA> | <LAMBDAE> )
 }
 
 void Lambda() #JexlLambda() :
@@ -792,9 +803,9 @@ void Lambda() #JexlLambda() :
 {
   <FUNCTION> Parameters() Block()
   |
-  Parameters() <LAMBDA> Block()
+  Parameters() ( <LAMBDA> Block() | <LAMBDAE> Expression() )
   |
-  Parameter() <LAMBDA> Block()
+  Parameter() ( <LAMBDA> Block() | <LAMBDAE> Expression() )
 }
 
 

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -789,7 +789,9 @@ void Parameters() #void : {}
 
 void LambdaLookahead() #void() : {}
 {
-  <FUNCTION> Parameters()
+  LOOKAHEAD(2) <FUNCTION> Parameters()
+  |
+  LOOKAHEAD(2) <FUNCTION> <LCURLY>
   |
   Parameters() ( <LAMBDA> | <LAMBDAE> )
   |
@@ -801,7 +803,9 @@ void Lambda() #JexlLambda() :
    pushFrame();
 }
 {
-  <FUNCTION> Parameters() Block()
+  LOOKAHEAD(2) <FUNCTION> Parameters() Block()
+  |
+  LOOKAHEAD(2) <FUNCTION> Block()
   |
   Parameters() ( <LAMBDA> Block() | <LAMBDAE> Expression() )
   |

--- a/src/site/xdoc/reference/syntax.xml
+++ b/src/site/xdoc/reference/syntax.xml
@@ -172,6 +172,10 @@
                         <code>var fun = function(x, y) { x + y }</code>
                         The following syntax is also supported
                         <code>var fun = (x, y) -> { x + y }</code>
+                        If the function has only one argument the parentheses may be ommited
+                        <code>var fun = x -> { x * x }</code>
+                        If the function is a simple expression the following syntax can also be used
+                        <code>var fun = (x, y) => x + y</code>
                         Calling a function follows the usual convention:
                         <code>fun(17, 25)</code>
                         <p>Note that functions can use local variables and parameters from their declaring script.

--- a/src/test/java/org/apache/commons/jexl3/LambdaExpressionTest.java
+++ b/src/test/java/org/apache/commons/jexl3/LambdaExpressionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.jexl3;
+
+import org.apache.commons.jexl3.internal.Engine;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests function/lambda/closure features.
+ */
+@SuppressWarnings({"UnnecessaryBoxing", "AssertEqualsBetweenInconvertibleTypes"})
+public class LambdaExpressionTest extends JexlTestCase {
+
+    public LambdaExpressionTest() {
+        super("LambdaExpressionTest");
+    }
+
+    @Test
+    public void testScriptContext() throws Exception {
+        JexlEngine jexl = new Engine();
+        JexlScript s = jexl.createScript("function(x) { x + x }");
+        Assert.assertEquals(42, s.execute(null, 21));
+        JexlScript s42 = jexl.createScript("s(21)");
+        JexlEvalContext ctxt = new JexlEvalContext();
+        ctxt.set("s", s);
+        Object result = s42.execute(ctxt);
+        Assert.assertEquals(42, result);
+        result = s42.execute(ctxt);
+        Assert.assertEquals(42, result);
+        s42 = jexl.createScript("x => x + x");
+        result = s42.execute(ctxt, 21);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
+    public void testLambda() throws Exception {
+        JexlEngine jexl = new Engine();
+        String strs = "var s = x => x + x; s(21)";
+        JexlScript s42 = jexl.createScript(strs);
+        Object result = s42.execute(null);
+        Assert.assertEquals(42, result);
+        strs = "var s = (x, y) => x + y; s(15, 27)";
+        s42 = jexl.createScript(strs);
+        result = s42.execute(null);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
+    public void testLambdaClosure() throws Exception {
+        JexlEngine jexl = new Engine();
+        String strs = "var t = 20; var s = (x, y) => x + y + t; s(15, 7)";
+        JexlScript s42 = jexl.createScript(strs);
+        Object result = s42.execute(null);
+        Assert.assertEquals(42, result);
+        strs = "var t = 20; var s = (x, y) => x + y + t; t = 54; s(15, 7)";
+        s42 = jexl.createScript(strs);
+        result = s42.execute(null);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
+    public void testLambdaLambda() throws Exception {
+        JexlEngine jexl = new Engine();
+
+        String strs = "( (x, y) => ( (xx, yy) => xx + yy)(x, y))(15, 27)";
+        JexlScript s42 = jexl.createScript(strs);
+        Object result = s42.execute(null);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
+    public void testNestLambda() throws Exception {
+        JexlEngine jexl = new Engine();
+        String strs = "( (x) => (y) => x + y)(15)(27)";
+        JexlScript s42 = jexl.createScript(strs);
+        Object result = s42.execute(null);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
+    public void testRecurse() throws Exception {
+        JexlEngine jexl = new Engine();
+        JexlContext jc = new MapContext();
+        try {
+            JexlScript script = jexl.createScript("var fact = x => (x <= 1) ? 1 : x * fact(x - 1); fact(5)");
+            int result = (Integer) script.execute(jc);
+            Assert.assertEquals(120, result);
+        } catch (JexlException xany) {
+            String msg = xany.toString();
+            throw xany;
+        }
+    }
+
+    @Test
+    public void testRecurse2() throws Exception {
+        JexlEngine jexl = new Engine();
+        JexlContext jc = new MapContext();
+        // adding some hoisted vars to get it confused
+        try {
+            JexlScript script = jexl.createScript(
+                    "var y = 1; var z = 1; "
+                    +"var fact = (x) => (x <= y) ? z : x * fact(x - 1); fact(6)");
+            int result = (Integer) script.execute(jc);
+            Assert.assertEquals(720, result);
+        } catch (JexlException xany) {
+            String msg = xany.toString();
+            throw xany;
+        }
+    }
+
+    @Test
+    public void testIdentity() throws Exception {
+        JexlEngine jexl = new Engine();
+        JexlScript script;
+        Object result;
+
+        script = jexl.createScript("(x) => x");
+        Assert.assertArrayEquals(new String[]{"x"}, script.getParameters());
+        result = script.execute(null, 42);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
+    public void testCurry1() throws Exception {
+        JexlEngine jexl = new Engine();
+        JexlScript script;
+        Object result;
+
+        JexlScript base = jexl.createScript("(x, y, z)=>x + y + z");
+        script = base.curry(5);
+        script = script.curry(15);
+        script = script.curry(22);
+        result = script.execute(null);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
+    public void testCurry2() throws Exception {
+        JexlEngine jexl = new Engine();
+        JexlScript script;
+        Object result;
+
+        JexlScript base = jexl.createScript("(x, y, z)=>x + y + z");
+        script = base.curry(5, 15);
+        script = script.curry(22);
+        result = script.execute(null);
+        Assert.assertEquals(42, result);
+    }
+}

--- a/src/test/java/org/apache/commons/jexl3/LambdaTest.java
+++ b/src/test/java/org/apache/commons/jexl3/LambdaTest.java
@@ -47,7 +47,7 @@ public class LambdaTest extends JexlTestCase {
         JexlEngine jexl = new Engine();
         JexlScript s = jexl.createScript("function(x) { x + x }");
         String fsstr = s.getParsedText(0);
-        Assert.assertEquals("(x)->{ x + x; }", fsstr);
+        Assert.assertEquals("x->{ x + x; }", fsstr);
         Assert.assertEquals(42, s.execute(null, 21));
         JexlScript s42 = jexl.createScript("s(21)");
         JexlEvalContext ctxt = new JexlEvalContext();

--- a/src/test/java/org/apache/commons/jexl3/LambdaTest.java
+++ b/src/test/java/org/apache/commons/jexl3/LambdaTest.java
@@ -62,6 +62,15 @@ public class LambdaTest extends JexlTestCase {
     }
 
     @Test
+    public void testParameterlessFunction() throws Exception {
+        JexlEngine jexl = new Engine();
+        String strs = "var s = function { 21 + 21 }; s()";
+        JexlScript s42 = jexl.createScript(strs);
+        Object result = s42.execute(null);
+        Assert.assertEquals(42, result);
+    }
+
+    @Test
     public void testLambda() throws Exception {
         JexlEngine jexl = new Engine();
         String strs = "var s = function(x) { x + x }; s(21)";


### PR DESCRIPTION
This PR introduces new lambda operator => (fat arrow), which allows lamda definitions to be less curly (i.e. without need to use curly brackets), when lambda consist of simple expression, like the following ``x => x*2``,
Also, parameterless functions can be defined without parentheses, like the following ``function{1+2}``