### PR TITLE
Introduce short-handed ternary operation x ? y

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
@@ -38,6 +38,7 @@ import org.apache.commons.jexl3.parser.ASTDivNode;
 import org.apache.commons.jexl3.parser.ASTEQNode;
 import org.apache.commons.jexl3.parser.ASTERNode;
 import org.apache.commons.jexl3.parser.ASTEWNode;
+import org.apache.commons.jexl3.parser.ASTElvisNode;
 import org.apache.commons.jexl3.parser.ASTEmptyFunction;
 import org.apache.commons.jexl3.parser.ASTEmptyMethod;
 import org.apache.commons.jexl3.parser.ASTExtendedLiteral;
@@ -908,16 +909,20 @@ public class Debugger extends ParserVisitor implements JexlInfo.Detail {
     @Override
     protected Object visit(ASTTernaryNode node, Object data) {
         accept(node.jjtGetChild(0), data);
+        builder.append("? ");
+        accept(node.jjtGetChild(1), data);
         if (node.jjtGetNumChildren() > 2) {
-            builder.append("? ");
-            accept(node.jjtGetChild(1), data);
             builder.append(" : ");
             accept(node.jjtGetChild(2), data);
-        } else {
-            builder.append("?:");
-            accept(node.jjtGetChild(1), data);
-
         }
+        return data;
+    }
+
+    @Override
+    protected Object visit(ASTElvisNode node, Object data) {
+        accept(node.jjtGetChild(0), data);
+        builder.append("?:");
+        accept(node.jjtGetChild(1), data);
         return data;
     }
 

--- a/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
@@ -50,6 +50,7 @@ import org.apache.commons.jexl3.parser.ASTDivNode;
 import org.apache.commons.jexl3.parser.ASTEQNode;
 import org.apache.commons.jexl3.parser.ASTERNode;
 import org.apache.commons.jexl3.parser.ASTEWNode;
+import org.apache.commons.jexl3.parser.ASTElvisNode;
 import org.apache.commons.jexl3.parser.ASTEmptyFunction;
 import org.apache.commons.jexl3.parser.ASTEmptyMethod;
 import org.apache.commons.jexl3.parser.ASTExtendedLiteral;
@@ -844,13 +845,17 @@ public class Interpreter extends InterpreterBase {
     @Override
     protected Object visit(ASTTernaryNode node, Object data) {
         Object condition = node.jjtGetChild(0).jjtAccept(this, data);
+        if (condition != null && arithmetic.toBoolean(condition))
+            return node.jjtGetChild(1).jjtAccept(this, data);
         if (node.jjtGetNumChildren() == 3) {
-            if (condition != null && arithmetic.toBoolean(condition)) {
-                return node.jjtGetChild(1).jjtAccept(this, data);
-            } else {
-                return node.jjtGetChild(2).jjtAccept(this, data);
-            }
+            return node.jjtGetChild(2).jjtAccept(this, data);
         }
+        return null;
+    }
+
+    @Override
+    protected Object visit(ASTElvisNode node, Object data) {
+        Object condition = node.jjtGetChild(0).jjtAccept(this, data);
         if (condition != null && arithmetic.toBoolean(condition)) {
             return condition;
         } else {

--- a/src/main/java/org/apache/commons/jexl3/internal/ScriptVisitor.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/ScriptVisitor.java
@@ -38,6 +38,7 @@ import org.apache.commons.jexl3.parser.ASTDivNode;
 import org.apache.commons.jexl3.parser.ASTEQNode;
 import org.apache.commons.jexl3.parser.ASTERNode;
 import org.apache.commons.jexl3.parser.ASTEWNode;
+import org.apache.commons.jexl3.parser.ASTElvisNode;
 import org.apache.commons.jexl3.parser.ASTEmptyFunction;
 import org.apache.commons.jexl3.parser.ASTEmptyMethod;
 import org.apache.commons.jexl3.parser.ASTExtendedLiteral;
@@ -191,6 +192,11 @@ public class ScriptVisitor extends ParserVisitor {
 
     @Override
     protected Object visit(ASTTernaryNode node, Object data) {
+        return visitNode(node, data);
+    }
+
+    @Override
+    protected Object visit(ASTElvisNode node, Object data) {
         return visitNode(node, data);
     }
 

--- a/src/main/java/org/apache/commons/jexl3/parser/JexlNode.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/JexlNode.java
@@ -241,6 +241,9 @@ public abstract class JexlNode extends SimpleNode {
             if (walk instanceof ASTTernaryNode) {
                 return true;
             }
+            if (walk instanceof ASTElvisNode) {
+                return true;
+            }
             if (walk instanceof ASTNullpNode) {
                 return true;
             }

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -458,13 +458,20 @@ void AssignmentExpression() #void : {}
 void ConditionalExpression() #void : {}
 {
   ConditionalOrExpression()
-  (
-    <QMARK> Expression() <COLON> Expression() #TernaryNode(3)
-  |
-    <ELVIS> Expression() #TernaryNode(2)
-  |
+  ( LOOKAHEAD(2) (
+    <QMARK> TernaryExpression() 
+    |
+    <ELVIS> Expression() #ElvisNode(2)
+    |
     <NULLP> Expression() #NullpNode(2)
-  )?
+  ) )?
+}
+
+void TernaryExpression() #void : {}
+{
+  LOOKAHEAD(Expression() <COLON>) Expression() <COLON> Expression() #TernaryNode(3)
+  |
+  Expression() #TernaryNode(2)
 }
 
 void ConditionalOrExpression() #void : {}

--- a/src/main/java/org/apache/commons/jexl3/parser/ParserVisitor.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/ParserVisitor.java
@@ -64,6 +64,8 @@ public abstract class ParserVisitor {
 
     protected abstract Object visit(ASTTernaryNode node, Object data);
 
+    protected abstract Object visit(ASTElvisNode node, Object data);
+
     protected abstract Object visit(ASTNullpNode node, Object data);
 
     protected abstract Object visit(ASTOrNode node, Object data);

--- a/src/site/xdoc/reference/syntax.xml
+++ b/src/site/xdoc/reference/syntax.xml
@@ -562,10 +562,26 @@
                     <td>Ternary conditional <code>?:</code> </td>
                     <td>
                         The usual ternary conditional operator <code>condition ? if_true : if_false</code> operator can be
-                        used as well as the abbreviation <code>value ?: if_false</code> which returns the <code>value</code> if
+                        used as well as the abbreviation <code>value ? if_true</code> which returns the <code>if_true</code> if
                         its evaluation is defined, non-null and non-false, e.g.
-                        <code>val1 ? val1 : val2</code> and
-                        <code>val1 ?: val2 </code> are equivalent.
+                        <code>val1 ? val2 : null</code> and
+                        <code>val1 ? val2 </code> are equivalent.
+                        <p>
+                            <strong>NOTE:</strong> The condition will evaluate to <code>false</code> when it
+                            refers to an undefined variable or <code>null</code> for all <code>JexlEngine</code>
+                            flag combinations. This allows explicit syntactic leniency and treats the condition
+                            'if undefined or null or false' the same way in all cases.
+                        </p>
+                        <p>Note that this operator can not be overloaded</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Binary conditional <code>?:</code> </td>
+                    <td>
+                        The binary conditional operator <code>value ?: if_false</code> returns the <code>value</code> if
+                        its evaluation is defined, non-null and non-false, e.g.
+                        <code>val1 ?: val2 </code> and
+                        <code>val1 ? val1 : val2</code> are equivalent.
                         <p>
                             <strong>NOTE:</strong> The condition will evaluate to <code>false</code> when it
                             refers to an undefined variable or <code>null</code> for all <code>JexlEngine</code>

--- a/src/test/java/org/apache/commons/jexl3/IfTest.java
+++ b/src/test/java/org/apache/commons/jexl3/IfTest.java
@@ -262,6 +262,65 @@ public class IfTest extends JexlTestCase {
 
     /**
      * Ternary operator condition undefined or null evaluates to false
+     * independantly of engine flags.
+     * @throws Exception
+     */
+    @Test
+    public void testTernaryOptional() throws Exception {
+        JexlEngine jexl = JEXL;
+
+        JexlEvalContext jc = new JexlEvalContext();
+        JexlExpression e = jexl.createExpression("x.y.z = foo ?'bar'");
+        Object o;
+
+        // undefined foo
+        for (int l = 0; l < 4; ++l) {
+            jc.setStrict((l & 1) == 0);
+            jc.setSilent((l & 2) != 0);
+            o = e.evaluate(jc);
+            Assert.assertNull(o);
+            o = jc.get("x.y.z");
+            Assert.assertNull(o);
+        }
+
+        jc.set("foo", null);
+
+        for (int l = 0; l < 4; ++l) {
+            jc.setStrict((l & 1) == 0);
+            jc.setSilent((l & 2) != 0);
+            o = e.evaluate(jc);
+            Assert.assertNull(o);
+            o = jc.get("x.y.z");
+            Assert.assertNull(o);
+        }
+
+        jc.set("foo", Boolean.FALSE);
+
+        for (int l = 0; l < 4; ++l) {
+            jc.setStrict((l & 1) == 0);
+            jc.setSilent((l & 2) != 0);
+            o = e.evaluate(jc);
+            Assert.assertNull(o);
+            o = jc.get("x.y.z");
+            Assert.assertNull(o);
+        }
+
+        jc.set("foo", Boolean.TRUE);
+
+        for (int l = 0; l < 4; ++l) {
+            jc.setStrict((l & 1) == 0);
+            jc.setSilent((l & 2) != 0);
+            o = e.evaluate(jc);
+            Assert.assertEquals("Should be bar", "bar", o);
+            o = jc.get("x.y.z");
+            Assert.assertEquals("Should be bar", "bar", o);
+        }
+
+        debuggerCheck(jexl);
+    }
+
+    /**
+     * Ternary operator condition undefined or null evaluates to false
      * independently of engine flags; same for null coalescing operator.
      * @throws Exception
      */


### PR DESCRIPTION
A short-handed ternary operation `x ? y` is an equivalent of the `x ? y : null`. This is differs from Elvis operator `x ?: y` which is effectively `x ? x : y`. The `x : y` operator is analogous to `if (x) y` statement with `else` part ommited