### PR TITLE
Speedup arithmetic evaluations

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -652,6 +652,17 @@ public class JexlArithmetic {
     }
 
     /**
+     * Default self assign implementation for Add.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left + right.
+     */
+    public Object selfAdd(Object left, Object right) {
+        return add(left, right);
+    }
+
+    /**
      * Divide the left value by the right.
      *
      * @param left  left argument
@@ -690,6 +701,17 @@ public class JexlArithmetic {
         }
         BigInteger result = l.divide(r);
         return narrowBigInteger(left, right, result);
+    }
+
+    /**
+     * Default self assign implementation for Divide.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left / right.
+     */
+    public Object selfDivide(Object left, Object right) {
+        return divide(left, right);
     }
 
     /**
@@ -734,6 +756,17 @@ public class JexlArithmetic {
     }
 
     /**
+     * Default self assign implementation for Mod.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left % right.
+     */
+    public Object selfMod(Object left, Object right) {
+        return mod(left, right);
+    }
+
+    /**
      * Multiply the left value by the right.
      *
      * @param left  left argument
@@ -765,6 +798,17 @@ public class JexlArithmetic {
     }
 
     /**
+     * Default self assign implementation for Multiply.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left * right.
+     */
+    public Object selfMultiply(Object left, Object right) {
+        return multiply(left, right);
+    }
+
+    /**
      * Subtract the right value from the left.
      *
      * @param left  left argument
@@ -793,6 +837,17 @@ public class JexlArithmetic {
         BigInteger r = toBigInteger(right);
         BigInteger result = l.subtract(r);
         return narrowBigInteger(left, right, result);
+    }
+
+    /**
+     * Default self assign implementation for Subtract.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left - right.
+     */
+    public Object selfSubtract(Object left, Object right) {
+        return subtract(left, right);
     }
 
     /**
@@ -976,6 +1031,17 @@ public class JexlArithmetic {
     }
 
     /**
+     * Default self assign implementation for bitwise and.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left &amp; right.
+     */
+    public Object selfAnd(Object left, Object right) {
+        return and(left, right);
+    }
+
+    /**
      * Performs a bitwise or.
      *
      * @param left  the left operand
@@ -989,6 +1055,17 @@ public class JexlArithmetic {
     }
 
     /**
+     * Default self assign implementation for bitwise or.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left | right.
+     */
+    public Object selfOr(Object left, Object right) {
+        return or(left, right);
+    }
+
+    /**
      * Performs a bitwise xor.
      *
      * @param left  the left operand
@@ -999,6 +1076,17 @@ public class JexlArithmetic {
         long l = toLong(left);
         long r = toLong(right);
         return l ^ r;
+    }
+
+    /**
+     * Default self assign implementation for bitwise xor.
+     *
+     * @param left  left argument
+     * @param right  right argument
+     * @return left ^ right.
+     */
+    public Object selfXor(Object left, Object right) {
+        return xor(left, right);
     }
 
     /**

--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -610,7 +610,7 @@ public class JexlArithmetic {
      * @param object  argument
      */
     protected boolean isIntegerPrecisionNumber(Object value) {
-       return value instanceof Integer || value instanceof Short || value instanceof Byte;
+        return value instanceof Integer || value instanceof Short || value instanceof Byte;
     }
 
     /**
@@ -619,7 +619,17 @@ public class JexlArithmetic {
      * @param object  argument
      */
     protected boolean isLongPrecisionNumber(Object value) {
-       return value instanceof Long || isIntegerPrecisionNumber(value);
+        return value instanceof Long || isIntegerPrecisionNumber(value);
+    }
+
+    protected BigInteger extendedLong(long x, byte msb) {
+        byte[] bi = new byte[9];
+        bi[0] = msb;
+        for (int i = 8; i > 0; i--) {
+            bi[i] = (byte)(x & 0xFF);
+            x >>= 8;
+        }
+        return new BigInteger(bi);
     }
 
     /**
@@ -643,11 +653,19 @@ public class JexlArithmetic {
         if (!strconcat) {
             try {
                 // if either are no longer than integers use that type
-                if (isIntegerPrecisionNumber(left) && isIntegerPrecisionNumber(right)) {
+                if (isLongPrecisionNumber(left) && isLongPrecisionNumber(right)) {
                     long l = ((Number) left).longValue();
                     long r = ((Number) right).longValue();
                     long result = l + r;
-                    if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
+                    if (left instanceof Long || right instanceof Long) {
+                        if ((l & r & ~result) < 0) {
+                            return extendedLong(result, (byte) -1);
+                        } else if ((~l & ~r & result) < 0) {
+                            return extendedLong(result, (byte) -0);
+                        } else {
+                            return result;
+                        }
+                    } else if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
                         return (int) result;
                     } else {
                         return result;
@@ -890,11 +908,19 @@ public class JexlArithmetic {
             return controlNullNullOperands();
         }
         // if either are no longer than integers use that type
-        if (isIntegerPrecisionNumber(left) && isIntegerPrecisionNumber(right)) {
+        if (isLongPrecisionNumber(left) && isLongPrecisionNumber(right)) {
             long l = ((Number) left).longValue();
             long r = ((Number) right).longValue();
             long result = l - r;
-            if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
+            if (left instanceof Long || right instanceof Long) {
+                if ((l & r & ~result) > 0) {
+                    return extendedLong(result, (byte) 0);
+                } else if ((~l & ~r & result) > 0) {
+                    return extendedLong(result, (byte) -1);
+                } else {
+                    return result;
+                }
+            } else if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
                 return (int) result;
             } else {
                 return result;

--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -605,6 +605,24 @@ public class JexlArithmetic {
     }
 
     /**
+     * Checks if object is eligible for fast integer arithmetic.
+     *
+     * @param object  argument
+     */
+    protected boolean isIntegerPrecisionNumber(Object value) {
+       return value instanceof Integer || value instanceof Short || value instanceof Byte;
+    }
+
+    /**
+     * Checks if object is eligible for fast long arithmetic.
+     *
+     * @param object  argument
+     */
+    protected boolean isLongPrecisionNumber(Object value) {
+       return value instanceof Long || isIntegerPrecisionNumber(value);
+    }
+
+    /**
      * Add two values together.
      * <p>
      * If any numeric add fails on coercion to the appropriate type,
@@ -624,6 +642,17 @@ public class JexlArithmetic {
                             : left instanceof String && right instanceof String;
         if (!strconcat) {
             try {
+                // if either are no longer than integers use that type
+                if (isIntegerPrecisionNumber(left) && isIntegerPrecisionNumber(right)) {
+                    long l = ((Number) left).longValue();
+                    long r = ((Number) right).longValue();
+                    long result = l + r;
+                    if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
+                        return (int) result;
+                    } else {
+                        return result;
+                    }
+                }
                 // if either are bigdecimal use that type
                 if (left instanceof BigDecimal || right instanceof BigDecimal) {
                     BigDecimal l = toBigDecimal(left);
@@ -673,6 +702,21 @@ public class JexlArithmetic {
     public Object divide(Object left, Object right) {
         if (left == null && right == null) {
             return controlNullNullOperands();
+        }
+        // if either are no longer than long use that type
+        if (isLongPrecisionNumber(left) && isLongPrecisionNumber(right)) {
+            long l = ((Number) left).longValue();
+            long r = ((Number) right).longValue();
+            if (r == 0L) {
+                throw new ArithmeticException("/");
+            }
+            long result = l / r;
+            if (!(left instanceof Long || right instanceof Long) 
+                    && result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
+                return (int) result;
+            } else {
+                return result;
+            }
         }
         // if either are bigdecimal use that type
         if (left instanceof BigDecimal || right instanceof BigDecimal) {
@@ -726,6 +770,21 @@ public class JexlArithmetic {
         if (left == null && right == null) {
             return controlNullNullOperands();
         }
+        // if either are no longer than long use that type
+        if (isLongPrecisionNumber(left) && isLongPrecisionNumber(right)) {
+            long l = ((Number) left).longValue();
+            long r = ((Number) right).longValue();
+            if (r == 0L) {
+                throw new ArithmeticException("%");
+            }
+            long result = l % r;
+            if (!(left instanceof Long || right instanceof Long) 
+                    && result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
+                return (int) result;
+            } else {
+                return result;
+            }
+        }
         // if either are bigdecimal use that type
         if (left instanceof BigDecimal || right instanceof BigDecimal) {
             BigDecimal l = toBigDecimal(left);
@@ -777,6 +836,17 @@ public class JexlArithmetic {
         if (left == null && right == null) {
             return controlNullNullOperands();
         }
+        // if either are no longer than integers use that type
+        if (isIntegerPrecisionNumber(left) && isIntegerPrecisionNumber(right)) {
+            long l = ((Number) left).longValue();
+            long r = ((Number) right).longValue();
+            long result = l * r;
+            if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
+                return (int) result;
+            } else {
+                return result;
+            }
+        }
         // if either are bigdecimal use that type
         if (left instanceof BigDecimal || right instanceof BigDecimal) {
             BigDecimal l = toBigDecimal(left);
@@ -818,6 +888,17 @@ public class JexlArithmetic {
     public Object subtract(Object left, Object right) {
         if (left == null && right == null) {
             return controlNullNullOperands();
+        }
+        // if either are no longer than integers use that type
+        if (isIntegerPrecisionNumber(left) && isIntegerPrecisionNumber(right)) {
+            long l = ((Number) left).longValue();
+            long r = ((Number) right).longValue();
+            long result = l - r;
+            if (result >= Integer.MIN_VALUE && result <= Integer.MAX_VALUE) {
+                return (int) result;
+            } else {
+                return result;
+            }
         }
         // if either are bigdecimal use that type
         if (left instanceof BigDecimal || right instanceof BigDecimal) {

--- a/src/main/java/org/apache/commons/jexl3/internal/Operators.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Operators.java
@@ -142,21 +142,21 @@ public class Operators {
         try {
             switch (operator) {
                 case SELF_ADD:
-                    return arithmetic.add(args[0], args[1]);
+                    return arithmetic.selfAdd(args[0], args[1]);
                 case SELF_SUBTRACT:
-                    return arithmetic.subtract(args[0], args[1]);
+                    return arithmetic.selfSubtract(args[0], args[1]);
                 case SELF_MULTIPLY:
-                    return arithmetic.multiply(args[0], args[1]);
+                    return arithmetic.selfMultiply(args[0], args[1]);
                 case SELF_DIVIDE:
-                    return arithmetic.divide(args[0], args[1]);
+                    return arithmetic.selfDivide(args[0], args[1]);
                 case SELF_MOD:
-                    return arithmetic.mod(args[0], args[1]);
+                    return arithmetic.selfMod(args[0], args[1]);
                 case SELF_AND:
-                    return arithmetic.and(args[0], args[1]);
+                    return arithmetic.selfAnd(args[0], args[1]);
                 case SELF_OR:
-                    return arithmetic.or(args[0], args[1]);
+                    return arithmetic.selfOr(args[0], args[1]);
                 case SELF_XOR:
-                    return arithmetic.xor(args[0], args[1]);
+                    return arithmetic.selfXor(args[0], args[1]);
                 default:
                     // unexpected, new operator added?
                     throw new UnsupportedOperationException(operator.getOperatorSymbol());

--- a/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
+++ b/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
@@ -130,15 +130,12 @@ public class ArithmeticTest extends JexlTestCase {
 
     @Test
     public void testOverflows() throws Exception {
-        asserter.setVariable("left", new Integer("1"));
-        asserter.setVariable("right", Integer.MAX_VALUE);
-        asserter.assertExpression("left + right", Long.valueOf("2147483648"));
-        asserter.setVariable("right", Integer.MIN_VALUE);
-        asserter.assertExpression("right - left", Long.valueOf("-2147483649"));
-        asserter.setVariable("right", Long.MAX_VALUE);
-        asserter.assertExpression("left + right", new BigInteger("9223372036854775808"));
-        asserter.setVariable("right", Long.MIN_VALUE);
-        asserter.assertExpression("right - left", new BigInteger("-9223372036854775809"));
+        asserter.assertExpression("1 + 2147483647", Long.valueOf("2147483648"));
+        asserter.assertExpression("-2147483648 - 1", Long.valueOf("-2147483649"));
+        asserter.assertExpression("1 + 9223372036854775807", new BigInteger("9223372036854775808"));
+        asserter.assertExpression("-1 + (-9223372036854775808)", new BigInteger("-9223372036854775809"));
+        asserter.assertExpression("-9223372036854775808 - 1", new BigInteger("-9223372036854775809"));
+        asserter.assertExpression("-1 - 9223372036854775808", new BigInteger("-9223372036854775809"));
     }
 
     /**

--- a/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
+++ b/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
@@ -128,6 +128,19 @@ public class ArithmeticTest extends JexlTestCase {
         asserter.assertExpression("right % left", new BigInteger("0"));
     }
 
+    @Test
+    public void testOverflows() throws Exception {
+        asserter.setVariable("left", new Integer("1"));
+        asserter.setVariable("right", Integer.MAX_VALUE);
+        asserter.assertExpression("left + right", Long.valueOf("2147483648"));
+        asserter.setVariable("right", Integer.MIN_VALUE);
+        asserter.assertExpression("right - left", Long.valueOf("-2147483649"));
+        asserter.setVariable("right", Long.MAX_VALUE);
+        asserter.assertExpression("left + right", new BigInteger("9223372036854775808"));
+        asserter.setVariable("right", Long.MIN_VALUE);
+        asserter.assertExpression("right - left", new BigInteger("-9223372036854775809"));
+    }
+
     /**
      * test some simple mathematical calculations
      */


### PR DESCRIPTION
As of now, Jexl inefficiently evaluates operators **+**,**-**,**/**,**%**,***** on Integer types as it casts operands to BigInteger type, applies operation and casts the result back. This for example, creates 3 BigInteger instances for a simple operation of 1+1. All evaluations on Integer types can be performed on corresponding **long** values, which is a magnitute of 200%-300% faster, in my measurments, and unneeded objects are not allocated on heap. Another point is request is to make selfAssign operators **overridable** in descendands of JexlArithmetic, instead of being able to be **oveloaded**, which can save the time by avoiding reflection.