### PR TITLE
JEXL-324 - Change grammar to make "new" require at least one argument

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -811,7 +811,7 @@ void FunctionCall() #void : {}
 
 void Constructor() #ConstructorNode() : {}
 {
-  <NEW> <LPAREN> [ Expression() ( <COMMA> Expression() )* ] <RPAREN>
+  <NEW> <LPAREN> Expression() ( <COMMA> Expression() )* <RPAREN>
 }
 
 void Parameter() #void :

--- a/src/test/java/org/apache/commons/jexl3/ParseFailuresTest.java
+++ b/src/test/java/org/apache/commons/jexl3/ParseFailuresTest.java
@@ -112,4 +112,17 @@ public class ParseFailuresTest extends JexlTestCase {
         }
     }
 
+    @Test
+    public void test324() throws Exception {
+        String badScript = "new()"; // malformed because new requires at least one argument
+        try {
+            JEXL.createScript(badScript);
+            Assert.fail("Parsing \"" + badScript
+                    + "\" should result in a JexlException.Parsing");
+        } catch (JexlException.Parsing pe) {
+            // expected
+            LOGGER.error(pe);
+        }
+    }
+
 }


### PR DESCRIPTION
This PR changes the JEXL grammar to force "new" to require at least one argument.  It also includes one new test case to cover the newly illegal syntax (new with arguments is already covered, but more coverage could be added if desired).

Another way to fix the NPE described in JEXL-324 would be to keep the grammar as-is, but tolerate new without any arguments within the Debugger class.  This would have less of a compatibility impact.

This is my first PR to the JEXL project.  I'm open to criticism.