### PR TITLE
Fix travis-ci scripts. Move to java 8 according to [JEXL-249].

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,20 @@
 
 language: java
 sudo: false
-
-dist: xenial
-
-jdk:
-  - openjdk6
-  - openjdk7
-  - openjdk8
-  - openjdk11
-  - openjdk12
-  - openjdk13
-  - openjdk-ea
-
+cache:
+  directories:
+    - $HOME/.m2
+matrix:
+  include:
+    - jdk: openjdk8
+    - jdk: openjdk11
+    - jdk: openjdk12
+    - jdk: openjdk13
+    - jdk: openjdk14
+    - jdk: oraclejdk11
+    - jdk: openjdk-ea
+  allow_failures:
+    - jdk: openjdk-ea
 after_success:
-  - mvn clean test jacoco:report coveralls:report
+  - mvn -V -B -e clean cobertura:cobertura coveralls:report
+

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>commons-parent</artifactId>
         <version>50</version>
     </parent>
-    
+
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-jexl3</artifactId>
     <version>3.2-SNAPSHOT</version>
@@ -32,8 +32,8 @@
     <inceptionYear>2001</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <commons.componentid>jexl</commons.componentid>
         <commons.module.name>org.apache.commons.jexl3</commons.module.name>
         <commons.release.version>3.1</commons.release.version>
@@ -55,12 +55,12 @@
         <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
         <checksyle.version>8.18</checksyle.version>
     </properties>
-    
+
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/commons-jexl.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/commons-jexl.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf/commons-jexl.git</url>
-    </scm> 
+    </scm>
     <issueManagement>
         <system>jira</system>
         <url>https://issues.apache.org/jira/browse/JEXL</url>
@@ -318,7 +318,7 @@
             </plugin>
         </plugins>
     </reporting>
-    
+
     <developers>
         <developer>
             <name>dIon Gillard</name>
@@ -367,7 +367,7 @@
             <email>henrib AT apache DOT org</email>
         </developer>
     </developers>
-    
+
     <contributors>
         <contributor>
             <name>Dmitri Blinov</name>


### PR DESCRIPTION
1.

In short, this pr fixed travis-ci script by deleting jdk6,7,12,13,ea to make travis-ci can pass.(and be neat.)
I will explain why we shall do this.

### for jdk 12,13,ea:

you use 
```     
        <maven.compiler.source>1.6</maven.compiler.source>
        <maven.compiler.target>1.6</maven.compiler.target>
```
which is not supported in jdk 12,13,ea.
that means, no matter how hard you try you can never pass the build.
so delete them.

### for jdk 6,7:

you use org.codehaus.mojo:animal-sniffer-maven-plugin:1.18 in your build progress, and org.codehaus.mojo:animal-sniffer-maven-plugin:1.18 use 52.0 for class version (jdk8), means jdk 6 and 7 cannot run its classes.
that means, no matter how hard you try you can never pass the build.
so delete them.

2.

I also added 
```
cache:
  directories:
    - $HOME/.m2
```
, in hope of making the build faster.