### PR TITLE
JEXL-336 support some escape control characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ target/
 /.classpath
 /.project
 /.settings/
+
+# intellij files
+.idea/
+/*.iml

--- a/src/main/java/org/apache/commons/jexl3/parser/StringParser.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/StringParser.java
@@ -99,9 +99,19 @@ public class StringParser {
                     // if c is not an escapable character, re-emmit the backslash before it
                     boolean notSeparator = sep == 0 ? c != '\'' && c != '"' : c != sep;
                     if (notSeparator && c != '\\') {
-                        strb.append('\\');
+                        switch (c) {
+                            // http://es5.github.io/x7.html#x7.8.4
+                            case 'b': strb.append('\b'); break; // backspace \u0008
+                            case 't': strb.append('\t'); break; // horizontal tab \u0009
+                            case 'n': strb.append('\n'); break; // line feed \u000A
+                            // We don't support vertical tab. If needed, the unicode (\u000B) should be used instead
+                            case 'f': strb.append('\f'); break; // form feed \u000C
+                            case 'r': strb.append('\r'); break; // carriage return \u000D
+                            default: strb.append('\\').append(c);
+                        }
+                    } else {
+                        strb.append(c);
                     }
-                    strb.append(c);
                 }
                 escape = false;
                 continue;

--- a/src/test/java/org/apache/commons/jexl3/parser/ParserTest.java
+++ b/src/test/java/org/apache/commons/jexl3/parser/ParserTest.java
@@ -87,4 +87,26 @@ public class ParserTest {
             Assert.assertEquals(id, esc1);
         }
     }
+
+    /**
+     * Test the escaped control characters.
+     */
+    @Test
+    public void testControlCharacters() {
+        // Both '' and "" are valid JEXL string
+        // The array of tuples where the first element is an expected result and the second element is a test string.
+        String[][] strings = new String[][] {
+            new String[] {"a\nb\tc", "'a\nb\tc'"}, // we still honor the actual characters
+            new String[] {"a\nb\tc", "'a\\nb\\tc'"},
+            new String[] {"a\nb\tc", "\"a\\nb\\tc\""},
+            new String[] {"\b\t\n\f\r", "'\\b\\t\\n\\f\\r'"},
+            new String[] {"'hi'", "'\\'hi\\''"},
+            new String[] {"\"hi\"", "'\"hi\"'"},
+            new String[] {"\"hi\"", "'\"hi\"'"},
+        };
+        for(String[] pair: strings) {
+            String output = StringParser.buildString(pair[1], true);
+            Assert.assertEquals(pair[0], output);
+        }
+    }
 }


### PR DESCRIPTION
I found that JEXL doesn't honor the escape control characters such as \n, \t. 

To reproduce this is simply evaluate this string `"a\t\b"` and it will yield `"a\t\b"` instead of `"a   b"`.

The test code can explain this better. Note that I have to escape twice because one is for Java and another one is for JEXL.
```java
String[][] strings = new String[][] {
    new String[] {"a\nb\tc", "'a\nb\tc'"}, // we still honor the actual characters
    new String[] {"a\nb\tc", "'a\\nb\\tc'"},
    new String[] {"a\nb\tc", "\"a\\nb\\tc\""},
    new String[] {"\b\t\n\f\r", "'\\b\\t\\n\\f\\r'"},
    new String[] {"'hi'", "'\\'hi\\''"},
    new String[] {"\"hi\"", "'\"hi\"'"},
    new String[] {"\"hi\"", "'\"hi\"'"},
};
for(String[] pair: strings) {
    String output = StringParser.buildString(pair[1], true);
    Assert.assertEquals(pair[0], output);
}
```
This change doesn't cover all control characters because it won't be used. I follow the ES5 JavaScript spec for the control characters that it supports except \v which Java itself doesn't support. I don't think it's being used that much anyway. Supporting \v is tricky. We can represent it with the unicode value (\u000B) but JEXL is Java and doing that in Java is not possible. Developers have to put the unicode in the String anyway when it's used in the host language. That's why \v is not included in the list.
 