### PR TITLE
Update to ph-javacc-maven-plugin 4.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,14 +148,9 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>javacc-maven-plugin</artifactId>
-                <version>2.6</version>
-                <!--
-        <groupId>com.helger.maven</groupId>
-        <artifactId>ph-javacc-maven-plugin</artifactId>
-        <version>4.0.3</version>
-                -->
+                <groupId>com.helger.maven</groupId>
+                <artifactId>ph-javacc-maven-plugin</artifactId>
+                <version>4.1.4</version>
                 <executions>
                     <execution>
                         <id>jexl-jjtree</id>

--- a/src/main/config/clirr-ignored.xml
+++ b/src/main/config/clirr-ignored.xml
@@ -47,4 +47,12 @@
         <method>java.lang.ClassLoader getClassLoader()</method>
         <to>java.lang.ClassLoader getClassLoader()</to>
     </difference>
+
+    <!-- The parser now expects/generates TokenMgrException instead of TokenMgrError -->
+    <difference>
+        <className>org/apache/commons/jexl3/JexlException$Tokenization</className>
+        <differenceType>7005</differenceType> <!-- parser now constructs this exception using TokenMgrException -->
+        <method>JexlException$Tokenization(org.apache.commons.jexl3.JexlInfo, org.apache.commons.jexl3.parser.TokenMgrError)</method>
+        <to>JexlException$Tokenization(org.apache.commons.jexl3.JexlInfo, org.apache.commons.jexl3.parser.TokenMgrException)</to>
+    </difference>
 </differences>

--- a/src/main/java/org/apache/commons/jexl3/JexlException.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlException.java
@@ -21,7 +21,7 @@ import org.apache.commons.jexl3.internal.Debugger;
 import org.apache.commons.jexl3.parser.JavaccError;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.jexl3.parser.ParseException;
-import org.apache.commons.jexl3.parser.TokenMgrError;
+import org.apache.commons.jexl3.parser.TokenMgrException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -294,7 +294,7 @@ public class JexlException extends RuntimeException {
          * @param info  the location info
          * @param cause the javacc cause
          */
-        public Tokenization(final JexlInfo info, final TokenMgrError cause) {
+        public Tokenization(final JexlInfo info, final TokenMgrException cause) {
             super(merge(info, cause), Objects.requireNonNull(cause).getAfter(), null);
         }
 

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -67,7 +67,7 @@ public final class Parser extends JexlParser
                              ? Collections.<String,Object>unmodifiableMap(pragmas)
                              : Collections.<String,Object>emptyMap());
             return script;
-        } catch (TokenMgrError xtme) {
+        } catch (TokenMgrException xtme) {
             throw new JexlException.Tokenization(info, xtme).clean();
         } catch (ParseException xparse) {
             Token errortok = errorToken(jj_lastpos, jj_scanpos, token.next, token);

--- a/src/main/java/org/apache/commons/jexl3/parser/ParserDefaultVisitor.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/ParserDefaultVisitor.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.jexl3.parser;
+
+/**
+ * This class only exists to prevent JJTree from generating it, since it
+ * expects {@link ParserVisitor} to be an interface, not an abstract class.
+ */
+class ParserDefaultVisitor { }

--- a/src/main/java/org/apache/commons/jexl3/parser/SimpleNode.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/SimpleNode.java
@@ -190,6 +190,11 @@ public class SimpleNode implements Node {
             }
         }
     }
+
+    @Override
+    public int getId() {
+        return id;
+    }
 }
 
 /* JavaCC - OriginalChecksum=7dff880883d088a37c1e3197e4b455a0 (do not edit this line) */

--- a/src/main/java/org/apache/commons/jexl3/parser/TokenMgrException.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/TokenMgrException.java
@@ -19,7 +19,7 @@ package org.apache.commons.jexl3.parser;
 /**
  * Token Manager Error.
  */
-public class TokenMgrError extends Error implements JavaccError {
+public class TokenMgrException extends RuntimeException implements JavaccError {
     /**
      * The version identifier for this Serializable class.
      * Increment only if the <i>serialized</i> form of the
@@ -94,19 +94,19 @@ public class TokenMgrError extends Error implements JavaccError {
 
 
     /** Constructor with message and reason. */
-    public TokenMgrError(final String message, final int reason) {
+    public TokenMgrException(final String message, final int reason) {
         super(message);
         errorCode = reason;
     }
 
     /** Full Constructor. */
-    public TokenMgrError(final boolean EOFSeen, final int lexState, final int errorLine, final int errorColumn, final String errorAfter, final char curChar, final int reason) {
+    public TokenMgrException(final boolean EOFSeen, final int lexState, final int errorLine, final int errorColumn, final String errorAfter, final int curChar, final int reason) {
         eof = EOFSeen;
         state = lexState;
         line = errorLine;
         column = errorColumn;
         after = errorAfter;
-        current = curChar;
+        current = (char) curChar;
         errorCode = reason;
     }
 


### PR DESCRIPTION
This includes a change to the parser generator version.

Some links relevant to TokenMgrError vs TokenMgrException:
https://markmail.org/message/uc3e4jrkdj37zati
https://github.com/phax/ParserGeneratorCC/issues/7