### PR TITLE
Use the "modern" parser template

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/internal/Engine.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Engine.java
@@ -45,7 +45,6 @@ import org.apache.commons.jexl3.parser.Parser;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -149,7 +148,7 @@ public class Engine extends JexlEngine {
      * The {@link Parser}; when parsing expressions, this engine uses the parser if it
      * is not already in use otherwise it will create a new temporary one.
      */
-    protected final Parser parser = new Parser(new StringReader(";")); //$NON-NLS-1$
+    protected final Parser parser = new Parser(";"); //$NON-NLS-1$
     /**
      * The expression max length to hit the cache.
      */
@@ -873,7 +872,7 @@ public class Engine extends JexlEngine {
             }
         } else {
             // ...otherwise parser was in use, create a new temporary one
-            final Parser lparser = new Parser(new StringReader(";"));
+            final Parser lparser = new Parser(";");
             script = lparser.parse(ninfo, features, src, scope);
         }
         if (source != null) {

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -20,6 +20,7 @@ options
 {
    MULTI=true;
    //STATIC=false;
+   JAVA_TEMPLATE_TYPE="modern";
    VISITOR=true;
    NODE_SCOPE_HOOK=true;
    NODE_CLASS="JexlNode";
@@ -59,7 +60,7 @@ public final class Parser extends JexlParser
             source = jexlSrc;
             pragmas = null;
             frame = scope;
-            ReInit(new java.io.StringReader(jexlSrc));
+            ReInit(jexlSrc);
             ASTJexlScript script = jexlFeatures.supportsScript()? JexlScript(scope) : JexlExpression(scope);
             script.jjtSetValue(info.detach());
             script.setFeatures(jexlFeatures);

--- a/src/test/java/org/apache/commons/jexl3/JexlTest.java
+++ b/src/test/java/org/apache/commons/jexl3/JexlTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.jexl3;
 
-import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -692,7 +691,7 @@ public class JexlTest extends JexlTestCase {
         jc.set("aString", "Hello");
         final Foo foo = new Foo();
         jc.set("foo", foo);
-        final Parser parser = new Parser(new StringReader(";"));
+        final Parser parser = new Parser(";");
         parser.parse(null, new JexlFeatures().register(false), "aString = 'World';", null);
 
         assertExpression(jc, "hello = 'world'", "world");

--- a/src/test/java/org/apache/commons/jexl3/parser/ParserTest.java
+++ b/src/test/java/org/apache/commons/jexl3/parser/ParserTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.jexl3.parser;
 
-import java.io.StringReader;
-
 import org.apache.commons.jexl3.JexlException;
 import org.apache.commons.jexl3.JexlFeatures;
 import org.junit.Assert;
@@ -36,7 +34,7 @@ public class ParserTest {
      */
     @Test
     public void testParse() throws Exception {
-        final Parser parser = new Parser(new StringReader(";"));
+        final Parser parser = new Parser(";");
         JexlNode sn;
         sn = parser.parse(null, FEATURES, "foo = 1;", null);
         Assert.assertNotNull("parsed node is null", sn);
@@ -52,7 +50,7 @@ public class ParserTest {
     public void testErrorAssign() throws Exception {
         final String[] ops = { "=", "+=", "-=", "/=", "*=", "^=", "&=", "|=" };
         for(final String op : ops) {
-            final Parser parser = new Parser(new StringReader(";"));
+            final Parser parser = new Parser(";");
             try {
                 final JexlNode sn = parser.parse(null, FEATURES, "foo() "+op+" 1;", null);
                 Assert.fail("should have failed on invalid assignment " + op);
@@ -66,7 +64,7 @@ public class ParserTest {
 
     @Test
     public void testErrorAmbiguous() throws Exception {
-        final Parser parser = new Parser(new StringReader(";"));
+        final Parser parser = new Parser(";");
         try {
             final JexlNode sn = parser.parse(null, FEATURES, "x = 1 y = 5", null);
             Assert.fail("should have failed on ambiguous statement");


### PR DESCRIPTION
This restores compatibility with JavaCC/JJTree. When set to classic,
ParserGeneratorCC and JavaCC/JJTree generate different output since
TokenMgrError is not supported by ParserGeneratorCC.