### PR TITLE
Fix small typos in comments throughout

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -499,7 +499,7 @@ public class JexlArithmetic {
      * Whether we consider the narrow class as a potential candidate for narrowing the source.
      *
      * @param narrow the target narrow class
-     * @param source the orginal source class
+     * @param source the original source class
      * @return true if attempt to narrow source to target is accepted
      */
     protected boolean narrowAccept(final Class<?> narrow, final Class<?> source) {

--- a/src/main/java/org/apache/commons/jexl3/JexlBuilder.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlBuilder.java
@@ -455,7 +455,7 @@ public class JexlBuilder {
      * If all methods are static, you may use the bean class instead of an instance as value.
      * </p>
      * <p>
-     * If the entry value is a class that has one contructor taking a JexlContext as argument, an instance
+     * If the entry value is a class that has one constructor taking a JexlContext as argument, an instance
      * of the namespace will be created at evaluation time. It might be a good idea to derive a JexlContext
      * to carry the information used by the namespace to avoid variable space pollution and strongly type
      * the constructor with this specialized JexlContext.

--- a/src/main/java/org/apache/commons/jexl3/JxltEngine.java
+++ b/src/main/java/org/apache/commons/jexl3/JxltEngine.java
@@ -225,7 +225,7 @@ public abstract class JxltEngine {
      *
      * @param info the {@link JexlInfo} source information
      * @param expression the {@link Template} string expression
-     * @return the {@link Expression}, null if silent and an error occured
+     * @return the {@link Expression}, null if silent and an error occurred
      * @throws Exception if an error occurs and the {@link JexlEngine} is not silent
      */
     public abstract Expression createExpression(JexlInfo info, String expression);
@@ -244,9 +244,9 @@ public abstract class JxltEngine {
      * $$   if (x == 42) {
      * Life, the universe, and everything
      * $$   } else if (x &gt; 42) {
-     * The value $(x} is over fourty-two
+     * The value $(x} is over forty-two
      * $$   } else {
-     * The value ${x} is under fourty-two
+     * The value ${x} is under forty-two
      * $$   }
      * $$ }
      * </pre></blockquote>
@@ -254,11 +254,11 @@ public abstract class JxltEngine {
      * <p>Will evaluate as:</p>
      *
      * <blockquote><pre>
-     * The value 1 is under fourty-two
-     * The value 3 is under fourty-two
-     * The value 5 is under fourty-two
+     * The value 1 is under forty-two
+     * The value 3 is under forty-two
+     * The value 5 is under forty-two
      * Life, the universe, and everything
-     * The value 169 is over fourty-two
+     * The value 169 is over forty-two
      * </pre></blockquote>
      *
      * <p>During evaluation, the template context exposes its writer as '$jexl' which is safe to use in this case.

--- a/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Debugger.java
@@ -314,7 +314,7 @@ public class Debugger extends ParserVisitor implements JexlInfo.Detail {
         depth -= 1;
         final Object value = accept(child, data);
         depth += 1;
-        // blocks, if, for & while dont need a ';' at end
+        // blocks, if, for & while don't need a ';' at end
         if (!(child instanceof ASTJexlScript
             || child instanceof ASTBlock
             || child instanceof ASTIfStatement
@@ -333,7 +333,7 @@ public class Debugger extends ParserVisitor implements JexlInfo.Detail {
     }
 
     /**
-     * Checks if a terminal node is the the cause to debug &amp; adds its representation to the rebuilt expression.
+     * Checks if a terminal node is the cause to debug &amp; adds its representation to the rebuilt expression.
      * @param node  the child node
      * @param image the child node token image (may be null)
      * @param data  visitor pattern argument

--- a/src/main/java/org/apache/commons/jexl3/internal/Engine.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Engine.java
@@ -501,7 +501,7 @@ public class Engine extends JexlEngine {
         if (context == null) {
             context = EMPTY_CONTEXT;
         }
-        // synthetize expr using register
+        // synthesize expr using register
         String src = trimSource(expr);
         src = "#0" + (src.charAt(0) == '[' ? "" : ".") + src;
         try {
@@ -530,7 +530,7 @@ public class Engine extends JexlEngine {
         if (context == null) {
             context = EMPTY_CONTEXT;
         }
-        // synthetize expr using register
+        // synthesize expr using register
         String src = trimSource(expr);
         src = "#0" + (src.charAt(0) == '[' ? "" : ".") + src + "=" + "#1";
         try {

--- a/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
@@ -699,7 +699,7 @@ public class Interpreter extends InterpreterBase {
                     int cnt = 0;
                     while (itemsIterator.hasNext()) {
                         cancelCheck(node);
-                        // reset loop varaible
+                        // reset loop variable
                         if (lexical && cnt++ > 0) {
                             // clean up but remain current
                             block.pop();
@@ -1566,7 +1566,7 @@ public class Interpreter extends InterpreterBase {
                     functor = context.get(methodName);
                     isavar = functor != null;
                 }
-                // name is a variable, cant be cached
+                // name is a variable, can't be cached
                 cacheable &= !isavar;
             }
         } else if (functor instanceof ASTIdentifierAccess) {

--- a/src/main/java/org/apache/commons/jexl3/internal/InterpreterBase.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/InterpreterBase.java
@@ -231,7 +231,7 @@ public abstract class InterpreterBase extends ParserVisitor {
                                 // not a class
                                 namespace = null;
                             }
-                        } // we know its a class
+                        } // we know it's a class
                     }
                 }
             }

--- a/src/main/java/org/apache/commons/jexl3/internal/Script.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Script.java
@@ -77,7 +77,7 @@ public class Script implements JexlScript, JexlExpression {
      * <p>
      * If the engine class loader has changed since we last evaluated this script, the script local cache
      * is invalidated to drop references to obsolete methods. It is not strictly necessary since the tryExecute
-     * will fail because the class wont match but it seems cleaner nevertheless.
+     * will fail because the class won't match but it seems cleaner nevertheless.
      * </p>
      */
     protected void checkCacheVersion() {

--- a/src/main/java/org/apache/commons/jexl3/internal/TemplateEngine.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/TemplateEngine.java
@@ -585,7 +585,7 @@ public final class TemplateEngine extends JxltEngine {
          * Creates a composite expression.
          * @param counters counters of expressions per type
          * @param list     the sub-expressions
-         * @param src      the source for this expresion if any
+         * @param src      the source for this expression if any
          */
         CompositeExpression(final int[] counters, final ArrayList<TemplateExpression> list, final TemplateExpression src) {
             super(src);
@@ -798,7 +798,7 @@ public final class TemplateEngine extends JxltEngine {
         for (int column = 0; column < size; ++column) {
             final char c = expr.charAt(column);
             switch (state) {
-                default: // in case we ever add new unified expresssion type
+                default: // in case we ever add new unified expression type
                     throw new UnsupportedOperationException("unexpected unified expression type");
                 case CONST:
                     if (c == immediateChar) {

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/BooleanGetExecutor.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/BooleanGetExecutor.java
@@ -32,7 +32,7 @@ public final class BooleanGetExecutor extends AbstractExecutor.Get {
      *
      * @param is the introspector
      * @param clazz the class to find the get method from
-     * @param property the the property name
+     * @param property the property name
      * @return the executor if found, null otherwise
      */
     public static BooleanGetExecutor discover(final Introspector is, final Class<?> clazz, final String property) {

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/ClassMap.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/ClassMap.java
@@ -54,7 +54,7 @@ final class ClassMap {
         try {
             return ClassMap.class.getMethod("cacheMiss");
         } catch (final Exception xio) {
-            // this really cant make an error...
+            // this really can't make an error...
             return null;
         }
     }

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/Introspector.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/Introspector.java
@@ -161,7 +161,7 @@ public final class Introspector {
      * @param c   Class in which the field search is taking place
      * @param key Name of the field being searched for
      * @return the desired field or null if it does not exist or is not accessible
-     * */
+     */
     public Field getField(final Class<?> c, final String key) {
         return getMap(c).getField(key);
     }

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
@@ -109,7 +109,7 @@ public class Permissions {
     /**
      * Checks whether a method explicitly disallows JEXL introspection.
      * <p>Since methods can be overridden, this also checks that no superclass or interface
-     * explictly disallows this methods.</p>
+     * explicitly disallows this methods.</p>
      * @param method the method to check
      * @return true if JEXL is allowed to introspect, false otherwise
      */
@@ -214,7 +214,7 @@ public class Permissions {
                 // unexpected, return no
                 return true;
             } catch (final SecurityException ex) {
-                // unexpected, cant do much
+                // unexpected, can't do much
                 return false;
             }
         }

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/Uberspect.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/Uberspect.java
@@ -165,7 +165,7 @@ public class Uberspect implements JexlUberspect {
      * @param c   Class in which the field search is taking place
      * @param key Name of the field being searched for
      * @return a {@link java.lang.reflect.Field} or null if it does not exist or is not accessible
-     * */
+     */
     public final Field getField(final Class<?> c, final String key) {
         return base().getField(c, key);
     }
@@ -459,7 +459,7 @@ public class Uberspect implements JexlUberspect {
                                 }
                                 // filter method that is an actual overload:
                                 // - not inherited (not declared by base class)
-                                // - nor overriden (not present in base class)
+                                // - nor overridden (not present in base class)
                                 if (!JexlArithmetic.class.equals(method.getDeclaringClass())) {
                                     try {
                                         JexlArithmetic.class.getMethod(method.getName(), method.getParameterTypes());

--- a/src/main/java/org/apache/commons/jexl3/introspection/JexlPropertySet.java
+++ b/src/main/java/org/apache/commons/jexl3/introspection/JexlPropertySet.java
@@ -43,7 +43,7 @@ public interface JexlPropertySet {
      * Attempts to reuse this JexlPropertySet, checking that it is compatible with
      * the actual set of arguments.
      *
-     * @param obj the object to invoke the the get upon
+     * @param obj the object to invoke the get upon
      * @param key the property key to get
      * @param value the property value to set
      * @return the result of the method invocation that should be checked by tryFailed to determine if it succeeded

--- a/src/main/java/org/apache/commons/jexl3/introspection/JexlSandbox.java
+++ b/src/main/java/org/apache/commons/jexl3/introspection/JexlSandbox.java
@@ -147,7 +147,7 @@ public final class JexlSandbox {
      * @return a copy of this sandbox
      */
     public JexlSandbox copy() {
-        // modified concurently at runtime so...
+        // modified concurrently at runtime so...
         final Map<String, Permissions> map = new ConcurrentHashMap<>();
         for (final Map.Entry<String, Permissions> entry : sandbox.entrySet()) {
             map.put(entry.getKey(), entry.getValue().copy());

--- a/src/main/java/org/apache/commons/jexl3/introspection/package.html
+++ b/src/main/java/org/apache/commons/jexl3/introspection/package.html
@@ -27,7 +27,7 @@
         <p>
             The Uberspectimpl is the concrete class implementing the Uberspect interface.
             Deriving from this class is the preferred way of augmenting Jexl introspective
-            capabilities when special needs to be fullfilled or when default behaviors
+            capabilities when special needs to be fulfilled or when default behaviors
             need to be modified.
         </p>
     </body>

--- a/src/main/java/org/apache/commons/jexl3/parser/JavaccError.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/JavaccError.java
@@ -35,7 +35,7 @@ public interface JavaccError {
 
     /**
      * Gets the last correct input.
-     * @return the string after which the error occured
+     * @return the string after which the error occurred
      */
     String getAfter();
 }

--- a/src/main/java/org/apache/commons/jexl3/parser/JexlNode.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/JexlNode.java
@@ -270,7 +270,7 @@ public abstract class JexlNode extends SimpleNode {
     /**
      * Check if a null evaluated expression is protected by a ternary expression.
      * <p>
-     * The rationale is that the ternary / elvis expressions are meant for the user to explictly take control
+     * The rationale is that the ternary / elvis expressions are meant for the user to explicitly take control
      * over the error generation; ie, ternaries can return null even if the engine in strict mode
      * would normally throw an exception.
      * </p>

--- a/src/main/java/org/apache/commons/jexl3/parser/JexlParser.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/JexlParser.java
@@ -267,7 +267,7 @@ public abstract class JexlParser extends StringParser {
 
     /**
      * Checks if a symbol is defined in lexical scopes.
-     * <p>This works with with parsed scripts in template resolution only.
+     * <p>This works with parsed scripts in template resolution only.
      * @param info an info linked to a node
      * @param symbol the symbol number
      * @return true if symbol accessible in lexical scope
@@ -485,12 +485,12 @@ public abstract class JexlParser extends StringParser {
     }
 
     /**
-     * Default implementation does nothing but is overriden by generated code.
+     * Default implementation does nothing but is overridden by generated code.
      * @param top whether the identifier is beginning an l/r value
      * @throws ParseException subclasses may throw this
      */
     protected void Identifier(final boolean top) throws ParseException {
-        // Overriden by generated code
+        // Overridden by generated code
     }
 
     /**


### PR DESCRIPTION
Along with the javadoc many of these are less important `//` comments, but might as well handle them all in one change.