### PR TITLE
Call Lock.lock before the try

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/Introspector.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/Introspector.java
@@ -300,15 +300,15 @@ public final class Introspector {
      */
     private ClassMap getMap(final Class<?> c) {
         ClassMap classMap;
+        lock.readLock().lock();
         try {
-            lock.readLock().lock();
             classMap = classMethodMaps.get(c);
         } finally {
             lock.readLock().unlock();
         }
         if (classMap == null) {
+            lock.writeLock().lock();
             try {
-                lock.writeLock().lock();
                 // try again
                 classMap = classMethodMaps.get(c);
                 if (classMap == null) {
@@ -334,8 +334,8 @@ public final class Introspector {
             cloader = getClass().getClassLoader();
         }
         if (!cloader.equals(loader)) {
+            lock.writeLock().lock();
             try {
-                lock.writeLock().lock();
                 // clean up constructor and class maps
                 final Iterator<Map.Entry<MethodKey, Constructor<?>>> mentries = constructorsMap.entrySet().iterator();
                 while (mentries.hasNext()) {


### PR DESCRIPTION
Probably not an issue with the ReentrantReadWriteLock implementation of
Lock.
Other lock usage in Introspector already calls lock before the try.

See:
https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/Lock.html
https://errorprone.info/bugpattern/LockNotBeforeTry