### PR TITLE
More parser compatibility fixes for JavaCC/JJTree

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/internal/Engine.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Engine.java
@@ -40,6 +40,7 @@ import org.apache.commons.jexl3.parser.ASTNumberLiteral;
 import org.apache.commons.jexl3.parser.ASTStringLiteral;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.jexl3.parser.Parser;
+import org.apache.commons.jexl3.parser.StringProvider;
 
 
 import org.apache.commons.logging.Log;
@@ -148,7 +149,7 @@ public class Engine extends JexlEngine {
      * The {@link Parser}; when parsing expressions, this engine uses the parser if it
      * is not already in use otherwise it will create a new temporary one.
      */
-    protected final Parser parser = new Parser(";"); //$NON-NLS-1$
+    protected final Parser parser = new Parser(new StringProvider(";")); //$NON-NLS-1$
     /**
      * The expression max length to hit the cache.
      */
@@ -872,7 +873,7 @@ public class Engine extends JexlEngine {
             }
         } else {
             // ...otherwise parser was in use, create a new temporary one
-            final Parser lparser = new Parser(";");
+            final Parser lparser = new Parser(new StringProvider(";"));
             script = lparser.parse(ninfo, features, src, scope);
         }
         if (source != null) {

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -19,7 +19,7 @@
 options
 {
    MULTI=true;
-   //STATIC=false;
+   STATIC=false;
    JAVA_TEMPLATE_TYPE="modern";
    VISITOR=true;
    NODE_SCOPE_HOOK=true;
@@ -454,16 +454,22 @@ Object pragmaValue() #void :
 {
 Token v;
 LinkedList<String> lstr = new LinkedList<String>();
+Object result;
 }
 {
-      LOOKAHEAD(1) v=<INTEGER_LITERAL> { return NumberParser.parseInteger(v.image); }
-    | LOOKAHEAD(1) v=<FLOAT_LITERAL> { return NumberParser.parseDouble(v.image); }
-    | LOOKAHEAD(1) v=<STRING_LITERAL> { return Parser.buildString(v.image, true); }
-    | LOOKAHEAD(1)  pragmaKey(lstr) { return stringify(lstr); }
-    | LOOKAHEAD(1) <TRUE> { return true; }
-    | LOOKAHEAD(1) <FALSE> { return false; }
-    | LOOKAHEAD(1) <NULL> { return null; }
-    | LOOKAHEAD(1) <NAN_LITERAL> { return Double.NaN; }
+  (
+      LOOKAHEAD(1) v=<INTEGER_LITERAL> { result = NumberParser.parseInteger(v.image); }
+    | LOOKAHEAD(1) v=<FLOAT_LITERAL> { result = NumberParser.parseDouble(v.image); }
+    | LOOKAHEAD(1) v=<STRING_LITERAL> { result = Parser.buildString(v.image, true); }
+    | LOOKAHEAD(1)  pragmaKey(lstr) { result = stringify(lstr); }
+    | LOOKAHEAD(1) <TRUE> { result = true; }
+    | LOOKAHEAD(1) <FALSE> { result = false; }
+    | LOOKAHEAD(1) <NULL> { result = null; }
+    | LOOKAHEAD(1) <NAN_LITERAL> { result = Double.NaN; }
+  )
+  {
+    return result;
+  }
 }
 
 


### PR DESCRIPTION
I'm not sure why STATIC=false was commented out? Without it, generating
the parser with JavaCC does not work.

The Parser constructor taking String throws ParseException (a checked
exception) when generated with JavaCC. I'm not sure why, but the
StringProvider exception does not.

For the pragmaValue changes, unreachable statements were generated. See
http://consoliii.blogspot.com/2014/05/javacc-modern-mode-how-to-resolve.html

With these changes I'm able to use JavaCC and everything passes again.