### PR TITLE
Support disabling fortran-style relational operators syntax

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/JexlFeatures.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlFeatures.java
@@ -60,7 +60,7 @@ public final class JexlFeatures {
         "register", "reserved variable", "local variable", "assign/modify",
         "global assign/modify", "array reference", "create instance", "loop", "function",
         "method call", "set/map/array literal", "pragma", "annotation", "script", "lexical", "lexicalShade",
-        "thin-arrow", "fat-arrow"
+        "thin-arrow", "fat-arrow", "extended relational operator"
     };
     /** Registers feature ordinal. */
     private static final int REGISTER = 0;
@@ -98,6 +98,8 @@ public final class JexlFeatures {
     public static final int THIN_ARROW = 16;
     /** Fat-arrow lambda syntax. */
     public static final int FAT_ARROW = 17;
+    /** Extended relational operator syntax. */
+    public static final int EXT_REL_OPER = 18;
 
     /**
      * Creates an all-features-enabled instance.
@@ -115,7 +117,8 @@ public final class JexlFeatures {
                 | (1L << PRAGMA)
                 | (1L << ANNOTATION)
                 | (1L << SCRIPT)
-                | (1L << THIN_ARROW);
+                | (1L << THIN_ARROW)
+                | (1L << EXT_REL_OPER);
         reservedNames = Collections.emptySet();
         nameSpaces = TEST_STR_FALSE;
     }
@@ -477,6 +480,26 @@ public final class JexlFeatures {
      */
     public boolean supportsFatArrow() {
         return getFeature(FAT_ARROW);
+    }
+
+    /**
+     * Sets whether extended relational operator syntax is enabled.
+     * <p>
+     * When disabled, extended relational operators (eq;ne;le;lt;ge;gt)
+     * will be treated as plain identifiers.
+     * @param flag true to enable, false to disable
+     * @return this features instance
+     */
+    public JexlFeatures extendedRelOper(final boolean flag) {
+        setFeature(EXT_REL_OPER, flag);
+        return this;
+    }
+
+    /**
+     * @return true if extended relational syntax is enabled, false otherwise
+     */
+    public boolean supportsExtendedRelOper() {
+        return getFeature(EXT_REL_OPER);
     }
 
     /**

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -56,6 +56,7 @@ public final class Parser extends JexlParser
             source = jexlSrc;
             pragmas = null;
             this.scope = jexlScope;
+            token_source.supportExtRelOper = jexlFeatures.supportsExtendedRelOper();
             ReInit(jexlSrc);
             ASTJexlScript script = jexlFeatures.supportsScript()? JexlScript(jexlScope) : JexlExpression(jexlScope);
             script.jjtSetValue(info.detach());
@@ -79,7 +80,9 @@ public final class Parser extends JexlParser
 
 PARSER_END(Parser)
 
-TOKEN_MGR_DECLS : {}
+TOKEN_MGR_DECLS : {
+    boolean supportExtRelOper = false;
+}
 
 /***************************************
  *     Skip & Number literal tokens
@@ -140,7 +143,7 @@ TOKEN_MGR_DECLS : {}
     | < ene : "!$" > // ends not equal
 }
 
-<DEFAULT> TOKEN : { /* COMPARISONS */
+<NEVER> TOKEN : { /* COMPARISONS */
       < EQ : "eq" >
     | < NE : "ne" >
     | < GT : "gt" >
@@ -237,7 +240,20 @@ TOKEN_MGR_DECLS : {}
 
 <DEFAULT> TOKEN : /* IDENTIFIERS */
 {
-  < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>|<ESCAPE>)* > { matchedToken.image = StringParser.unescapeIdentifier(matchedToken.image); }
+  < IDENTIFIER: <LETTER> (<LETTER>|<DIGIT>|<ESCAPE>)* > 
+  { 
+      matchedToken.image = StringParser.unescapeIdentifier(matchedToken.image); 
+      if (supportExtRelOper) {
+          switch (matchedToken.image) {
+             case "ne" : matchedToken.kind = NE; break;
+             case "eq" : matchedToken.kind = EQ; break;
+             case "lt" : matchedToken.kind = LT; break;
+             case "le" : matchedToken.kind = LE; break;
+             case "gt" : matchedToken.kind = GT; break;
+             case "ge" : matchedToken.kind = GT; break;
+          }
+      }
+  }
 |
   < #LETTER: [ "a"-"z", "A"-"Z", "_", "$", "@" ] >
 |

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -250,7 +250,7 @@ TOKEN_MGR_DECLS : {
              case "lt" : matchedToken.kind = LT; break;
              case "le" : matchedToken.kind = LE; break;
              case "gt" : matchedToken.kind = GT; break;
-             case "ge" : matchedToken.kind = GT; break;
+             case "ge" : matchedToken.kind = GE; break;
           }
       }
   }

--- a/src/test/java/org/apache/commons/jexl3/FeaturesTest.java
+++ b/src/test/java/org/apache/commons/jexl3/FeaturesTest.java
@@ -289,4 +289,18 @@ public class FeaturesTest extends JexlTestCase {
         checkFeature(f, scripts);
     }
 
+    @Test
+    public void testExtendedRelationalOper() throws Exception {
+        final JexlFeatures f = new JexlFeatures().extendedRelOper(false);
+        final String[] scripts = new String[]{
+            "1 eq 1",
+            "2 ne 3",
+            "1 lt 2",
+            "3 le 3",
+            "4 gt 2",
+            "3 ge 2"
+        };
+        checkFeature(f, scripts);
+    }
+
 }


### PR DESCRIPTION
Introduce JexlFeature to disable 'eq','ne','gt','ge','le','lt' as operators, treat as plain identifiers