### PR TITLE
JEXL-386: Fix non-inheritable permissions on interfaces in an inheritable sandbox.

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/introspection/JexlSandbox.java
+++ b/src/main/java/org/apache/commons/jexl3/introspection/JexlSandbox.java
@@ -648,8 +648,12 @@ public final class JexlSandbox {
                 // find first inherited interface that defines permissions
                 for (final Class<?> inter : clazz.getInterfaces()) {
                     permissions = sandbox.get(inter.getName());
-                    if (permissions != null && permissions.isInheritable()) {
-                        break;
+                    if (permissions != null) {
+                        if (permissions.isInheritable()) {
+                            break;
+                        } else {
+                            permissions = null;
+                        }
                     }
                 }
                 // nothing defined yet, find first superclass that defines permissions

--- a/src/test/java/org/apache/commons/jexl3/introspection/SandboxTest.java
+++ b/src/test/java/org/apache/commons/jexl3/introspection/SandboxTest.java
@@ -18,7 +18,6 @@ package org.apache.commons.jexl3.introspection;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +32,6 @@ import org.apache.commons.jexl3.JexlTestCase;
 import org.apache.commons.jexl3.MapContext;
 import org.apache.commons.jexl3.annotations.NoJexl;
 
-import org.apache.commons.jexl3.internal.introspection.Permissions;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -458,6 +456,34 @@ public class SandboxTest extends JexlTestCase {
         } catch (final JexlException xjm) {
             // ok
             LOGGER.debug(xjm.toString());
+        }
+    }
+
+    public interface SomeInterface {
+        int bar();
+    }
+
+    public static class SomeFoo implements SomeInterface {
+        @Override
+        public int bar() {
+            return 1;
+        }
+    }
+
+    @Test
+    public void testSandboxInheritWithNonInheritedPermission() {
+        final SomeFoo foo = new SomeFoo();
+        final JexlSandbox sandbox = new JexlSandbox(false, true);
+        sandbox.permissions(SomeInterface.class.getName(), false, true, true, true);
+        final JexlEngine sjexl = new JexlBuilder().sandbox(sandbox).safe(false).strict(true).create();
+        final JexlScript someOp = sjexl.createScript("foo.bar()", "foo");
+
+        try {
+            someOp.execute(null, foo);
+            Assert.fail("should not be possible");
+        } catch (final JexlException e) {
+            // ok
+            LOGGER.debug(e.toString());
         }
     }
 


### PR DESCRIPTION
Currently, if a sandbox is inheritable, a non-inheritable permission on an interface will have no effect. This fix addressed this issue by reset the permission object when iterating super interfaces.