### PR TITLE
Remove an unnecessary equals override

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
@@ -75,11 +75,6 @@ public class Permissions implements JexlPermissions {
 
         boolean isEmpty() { return nojexl.isEmpty(); }
 
-        @Override
-        public boolean equals(final Object o) {
-            return o == this;
-        }
-
         NoJexlClass getNoJexl(final Class<?> clazz) {
             return nojexl.get(classKey(clazz));
         }


### PR DESCRIPTION
to resolve a false positive warning about not also overriding hashCode