### PR TITLE
[JEXL-446] Accept module packages with qualified exports

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -54,6 +54,7 @@ Bugs Fixed in 3.6.0:
 * JEXL-441:     Tokenization error if "\n" in template expression.
 * JEXL-439:     When using reference capture, incorrect scoping when local variable redefines a captured symbo
 * JEXL-437:     Semicolons actually not optional between function calls on separate lines
+* JEXL-446:     ClassTool module inspection is too strict
 
 
 ========================================================================================================================

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/ClassTool.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/ClassTool.java
@@ -30,12 +30,15 @@ final class ClassTool {
     private static final MethodHandle GET_PKGNAME;
     /** The Module.isExported(String packageName) method. */
     private static final MethodHandle IS_EXPORTED;
+    /** The Module of JEXL itself. */
+    private static final Object JEXL_MODULE;
 
     static {
         final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
         MethodHandle getModule = null;
         MethodHandle getPackageName = null;
         MethodHandle isExported = null;
+        Object myModule = null;
         try {
             final Class<?> modulec = ClassTool.class.getClassLoader().loadClass("java.lang.Module");
             if (modulec != null) {
@@ -43,13 +46,15 @@ final class ClassTool {
                 if (getModule != null) {
                     getPackageName = LOOKUP.findVirtual(Class.class, "getPackageName", MethodType.methodType(String.class));
                     if (getPackageName != null) {
-                        isExported = LOOKUP.findVirtual(modulec, "isExported", MethodType.methodType(boolean.class, String.class));
+                        myModule = getModule.invoke(ClassTool.class);
+                        isExported = LOOKUP.findVirtual(modulec, "isExported", MethodType.methodType(boolean.class, String.class, modulec));
                     }
                 }
             }
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
             // ignore all
         }
+        JEXL_MODULE = myModule;
         GET_MODULE = getModule;
         GET_PKGNAME = getPackageName;
         IS_EXPORTED = isExported;
@@ -103,18 +108,25 @@ final class ClassTool {
     }
 
     /**
-     * Checks whether a class is exported by its module (Java 9+).
+     * Checks whether a class is exported by its module (Java 9+) to JEXL.
      * The code performs the following sequence through reflection (since the same jar can run
      * on a Java8 or Java9+ runtime and the module features does not exist on 8).
      * {@code
+     * Module jexlModule ClassTool.getClass().getModule();
      * Module module = declarator.getModule();
-     * return module.isExported(declarator.getPackageName());
+     * return module.isExported(declarator.getPackageName(), jexlModule);
      * }
      * This is required since some classes and methods may not be exported thus not callable through
-     * reflection.
+     * reflection.  A package can be non-exported, <i>unconditionally</i> exported (to all reading
+     * modules), or use <i>qualified</i> exports to only export the package to specifically named
+     * modules.  This method is only concerned with whether JEXL may reflectively access the
+     * package, so a qualified export naming the JEXL module is the least-privilege access required.
+     * The declarator's module may also use: unqualified exports, qualified {@code opens}, or
+     * unqualified {@code opens}, in increasing order of privilege; the last two allow reflective
+     * access to non-public members and are not recommended.
      *
      * @param declarator the class
-     * @return true if class is exported or no module support exists
+     * @return true if class is exported (to JEXL) or no module support exists
      */
     static boolean isExported(final Class<?> declarator) {
         if (IS_EXPORTED != null) {
@@ -122,7 +134,7 @@ final class ClassTool {
                 final Object module = GET_MODULE.invoke(declarator);
                 if (module != null) {
                     final String pkgName = (String) GET_PKGNAME.invoke(declarator);
-                    return (Boolean) IS_EXPORTED.invoke(module, pkgName);
+                    return (Boolean) IS_EXPORTED.invoke(module, pkgName, JEXL_MODULE);
                 }
             } catch (final Throwable e) {
                 // ignore


### PR DESCRIPTION
`ClassTool.isExported(Class)` attempts to check, on Java 9+, whether the package
containing the class is _exported_ per the Java Module System.  A package must at
least be exported in order for its `public` members to be *read* via reflection by
another module.  It uses reflection to access the Java 9+ APIs so that JEXL can
still run on Java 8, and the check is bypassed in this case.

The issue was the use of `Module.isExported(String)`, which accepts only a package
name.  This method is defined to return `true` if and only if the named package is
_unconditionally_ exported, i.e. to any module that wants to read it.  But Java also
supports _qualified_ exports, where a module can export a package **only** to one
or more specifically named other modules; this is a mechanism for least-privilege
access.  For example:

    module org.example.module {
      exports org.example.module.api; // unqualified or unconditional
      exports org.example.module.scripting to org.apache.commons.jexl3; // qualified
    }

JEXL 3.5.0 would accept classes from the `o.e.m.api` package in the above example, but
reject classes in `o.e.m.scripting` even though Java would permit access to the JEXL module.

The fix is to use a different overload: `Module.isExported(String, Module)` passing JEXL's
own module as the 2nd method parameter.  This continues to return `true` for the unqualified
or unconditional exports, but now also returns `true` for the qualified form as well.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [X] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [X] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
