### PR TITLE
JEXL-459: fix empty/size functions to handle exceptions properly;

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@ This is a feature and maintenance release. Java 8 or later is required.
 Bugs Fixed in 3.6.3:
 ====================
 
+o JEXL-459:  Empty/size functions swallow all exceptions with no trace.
 o JEXL-458:  Improve permissions expressivity.
 o JEXL-457:  Reduce default exposure for RESTRICTED JexlPermissions.
 o JEXL-456:  Change in template parser behavior.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -30,6 +30,7 @@
         <release version="3.6.3" date="YYYY-MM-DD"
                  description="This is a feature and maintenance release. Java 8 or later is required.">
             <!-- FIX -->
+            <action dev="henrib" type="fix" issue="JEXL-459" due-to="Mirek Hankus">Empty/size functions swallow all exceptions with no trace.</action>
             <action dev="henrib" type="fix" issue="JEXL-458" due-to="Daniil Averin">Improve permissions expressivity</action>
             <action dev="henrib" type="fix" issue="JEXL-457" due-to="Daniil Averin">Reduce default exposure for RESTRICTED JexlPermissions</action>
             <action dev="henrib" type="fix" issue="JEXL-456" due-to="Vincent Bussol">Change in template parser behavior.</action>

--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -1022,10 +1022,10 @@ public class JexlArithmetic {
      * @return the evaluated result on success, or the supplier itself on JexlException
      * @since 3.6.3
      */
-    public Object evaluate(Log logger, Supplier<Object> arg) {
+    public Object evaluate(final Log logger, final Supplier<Object> arg) {
         try {
             return arg.get();
-        } catch (JexlException e) {
+        } catch (final JexlException e) {
             if (logger != null && logger.isWarnEnabled()) {
                 Throwable t = e.getCause();
                 if (t == null) {

--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -1012,14 +1012,13 @@ public class JexlArithmetic {
      *
      * <p>Used primarily by {@link #empty(Object)} and {@link #size(Object)} to guard argument evaluation.
      * If evaluation succeeds, returns the supplier's result. If a {@link JexlException} occurs, logs a
-     * warning and returns the supplier itself.</p>
+     * warning and returns {@link JexlEngine#TRY_FAILED} as an exception-occurred sentinel to the caller.</p>
      *
-     * <p>This method is public to allow overriding. Implementations that change the exception handling
-     * behavior must still return the supplier on failure to maintain the contract.</p>
+     * <p>This method is public to allow overriding.</p>
      *
      * @param logger the logger for warning messages; may be null
      * @param arg the supplier providing the argument to evaluate
-     * @return the evaluated result on success, or the supplier itself on JexlException
+     * @return the evaluated result on success or {@link JexlEngine#TRY_FAILED} on failure
      * @since 3.6.3
      */
     public Object evaluate(final Log logger, final Supplier<Object> arg) {
@@ -1027,15 +1026,18 @@ public class JexlArithmetic {
             return arg.get();
         } catch (final JexlException e) {
             if (logger != null && logger.isWarnEnabled()) {
-                Throwable t = e.getCause();
+                final String em = e.getMessage();
+                final Throwable t = e.getCause();
                 if (t == null) {
-                    logger.warn(e.getMessage(), e.clean());
+                    logger.warn(em, e.clean());
                 } else {
-                    logger.warn(e.getMessage() + ", " + t.getMessage(), JexlException.clean(t));
+                    final String tm = t.getMessage();
+                    String warning = em != null ? (tm != null ? em + ", " + tm : em) : tm;
+                    logger.warn(warning, JexlException.clean(t));
                 }
             }
         }
-        return arg;
+        return JexlEngine.TRY_FAILED;
     }
 
     /**

--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -30,11 +30,13 @@ import java.math.MathContext;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.jexl3.introspection.JexlMethod;
+import org.apache.commons.logging.Log;
 
 /**
  * Perform arithmetic, implements JexlOperator methods.
@@ -1003,6 +1005,32 @@ public class JexlArithmetic {
             return (byte) ((Byte) val + incr);
         }
         throw new ArithmeticException("Object "+(incr < 0? "decrement":"increment")+":(" + val + ")");
+    }
+
+    /**
+     * Evaluates a supplier argument, eventually catching and logging any JexlException.
+     *
+     * <p>Used primarily by {@link #empty(Object)} and {@link #size(Object)} to guard argument evaluation.
+     * If evaluation succeeds, returns the supplier's result. If a {@link JexlException} occurs, logs a
+     * warning and returns the supplier itself.</p>
+     *
+     * <p>This method is public to allow overriding. Implementations that change the exception handling
+     * behavior must still return the supplier on failure to maintain the contract.</p>
+     *
+     * @param logger the logger for warning messages; may be null
+     * @param arg the supplier providing the argument to evaluate
+     * @return the evaluated result on success, or the supplier itself on JexlException
+     * @since 3.6.3
+     */
+    public Object evaluate(Log logger, Supplier<Object> arg) {
+        try {
+            return arg.get();
+        } catch (JexlException e) {
+            if (logger != null && logger.isWarnEnabled()) {
+                logger.warn(e.getMessage(), e);
+            }
+        }
+        return arg;
     }
 
     /**

--- a/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlArithmetic.java
@@ -1027,7 +1027,12 @@ public class JexlArithmetic {
             return arg.get();
         } catch (JexlException e) {
             if (logger != null && logger.isWarnEnabled()) {
-                logger.warn(e.getMessage(), e);
+                Throwable t = e.getCause();
+                if (t == null) {
+                    logger.warn(e.getMessage(), e.clean());
+                } else {
+                    logger.warn(e.getMessage() + ", " + t.getMessage(), JexlException.clean(t));
+                }
             }
         }
         return arg;

--- a/src/main/java/org/apache/commons/jexl3/JexlBuilder.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlBuilder.java
@@ -736,7 +736,7 @@ public class JexlBuilder {
      * Sets whether the engine will throw JexlException during evaluation when an error is triggered.
      * <p>When <em>not</em> silent, the engine throws an exception when the evaluation triggers an exception or an
      * error.</p>
-     * <p>It is recommended to use <em>silent(true)</em> as an explicit default.</p>
+     * <p>It is recommended to use <em>silent(false)</em> as an explicit default.</p>
      *
      * @param flag true means no JexlException will occur, false allows them
      * @return this builder
@@ -795,7 +795,7 @@ public class JexlBuilder {
     }
 
     /**
-     * Sets whether the engine considers unknown variables, methods, functions and constructors as errors or
+     * Sets whether the engine considers unknown variables, methods, functions, and constructors as errors or
      * evaluates them as null.
      * <p>When <em>not</em> strict, operators or functions using null operands return null on evaluation. When
      * strict, those raise exceptions.</p>

--- a/src/main/java/org/apache/commons/jexl3/JexlCache.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlCache.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * Caching scripts or templates interface.
+ * Caching script or template interface.
  *
  * @param <K> source
  * @param <V> script or template
@@ -54,7 +54,7 @@ public interface JexlCache<K, V> {
     }
 
     /**
-     * Gets a value from cache.
+     * Gets a value from this cache.
      *
      * @param key the cache entry key
      * @return the cache entry value
@@ -62,7 +62,7 @@ public interface JexlCache<K, V> {
     V get(K key);
 
     /**
-     * Puts a value in cache.
+     * Puts a value in this cache.
      *
      * @param key    the cache entry key
      * @param script the cache entry value

--- a/src/main/java/org/apache/commons/jexl3/JexlException.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlException.java
@@ -744,10 +744,9 @@ public class JexlException extends RuntimeException {
                 if (startsWithAny(CLEAN_STOP, className)) {
                     break;
                 }
-                if (startsWithAny(CLEAN_SKIP, className)) {
-                    continue;
+                if (!startsWithAny(CLEAN_SKIP, className)) {
+                    stackJexl.add(se);
                 }
-                stackJexl.add(se);
             }
             xthrow.setStackTrace(stackJexl.toArray(EMPTY_STACK_TRACE_ELEMENT_ARRAY));
         }
@@ -760,7 +759,7 @@ public class JexlException extends RuntimeException {
      * @param name the name to check
      * @return true if the name starts with any of the prefixes, false otherwise
      */
-    private static boolean startsWithAny(final List<String> prefixes, final String name) {
+    private static boolean startsWithAny(final String[] prefixes, final String name) {
         for (final String prefix : prefixes) {
             if (name.startsWith(prefix)) {
                 return true;
@@ -770,25 +769,25 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * A static, immutable list of package names that will be skipped during
+     * A static array of package names that will be skipped during
      * exception stack-trace cleansing.
      */
-    private static final List<String> CLEAN_SKIP = Arrays.asList(
+    private static final String[] CLEAN_SKIP = {
       "org.apache.commons.jexl3.internal",
       "org.apache.commons.jexl3.parser",
       "java.lang.reflect",
       "sun.reflect"
-    );
+    };
 
     /**
-     * A static, immutable list of package names that will be considered as a stop point during
+     * A static array of package names that will be considered as a stop point during
      * exception stack-trace cleansing.
      * <p>
      * All stacktrace elements occurring after one of these packages matches an element class name
      * will be discarded.
      * </p>
      */
-    private static final List<String> CLEAN_STOP = Collections.singletonList("org.junit");
+    private static final String[] CLEAN_STOP = { "org.junit" };
 
     /**
      * Gets the most specific information attached to a node.

--- a/src/main/java/org/apache/commons/jexl3/JexlException.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlException.java
@@ -23,8 +23,6 @@ import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 

--- a/src/main/java/org/apache/commons/jexl3/JexlException.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlException.java
@@ -23,6 +23,8 @@ import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -236,7 +238,7 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Thrown when a method or ctor is unknown, ambiguous or inaccessible.
+     * Thrown when a method or ctor is unknown, ambiguous, or inaccessible.
      *
      * @since 3.0
      */
@@ -322,7 +324,7 @@ public class JexlException extends RuntimeException {
         }
 
         /**
-         * Gets  the method signature
+         * Gets the method signature.
          *
          * @return the method signature
          * @since 3.2
@@ -728,10 +730,10 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Cleans a Throwable from any org.apache.commons.jexl3.internal stack trace element.
+     * Cleans a Throwable from cluttering stack trace elements.
      *
      * @param <X>    the throwable type
-     * @param xthrow the thowable
+     * @param xthrow the throwable
      * @return the throwable
      */
      static <X extends Throwable> X clean(final X xthrow) {
@@ -739,15 +741,54 @@ public class JexlException extends RuntimeException {
             final List<StackTraceElement> stackJexl = new ArrayList<>();
             for (final StackTraceElement se : xthrow.getStackTrace()) {
                 final String className = se.getClassName();
-                if (!className.startsWith("org.apache.commons.jexl3.internal")
-                        && !className.startsWith("org.apache.commons.jexl3.parser")) {
-                    stackJexl.add(se);
+                if (startsWithAny(CLEAN_STOP, className)) {
+                    break;
                 }
+                if (startsWithAny(CLEAN_SKIP, className)) {
+                    continue;
+                }
+                stackJexl.add(se);
             }
             xthrow.setStackTrace(stackJexl.toArray(EMPTY_STACK_TRACE_ELEMENT_ARRAY));
         }
         return xthrow;
     }
+
+    /**
+     * Checks whether a given name starts with any of the given prefixes.
+     * @param prefixes the prefixes to check
+     * @param name the name to check
+     * @return true if the name starts with any of the prefixes, false otherwise
+     */
+    private static boolean startsWithAny(final List<String> prefixes, final String name) {
+        for (final String prefix : prefixes) {
+            if (name.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A static, immutable list of package names that will be skipped during
+     * exception stack-trace cleansing.
+     */
+    private static final List<String> CLEAN_SKIP = Arrays.asList(
+      "org.apache.commons.jexl3.internal",
+      "org.apache.commons.jexl3.parser",
+      "java.lang.reflect",
+      "sun.reflect"
+    );
+
+    /**
+     * A static, immutable list of package names that will be considered as a stop point during
+     * exception stack-trace cleansing.
+     * <p>
+     * All stacktrace elements occurring after one of these packages matches an element class name
+     * will be discarded.
+     * </p>
+     */
+    private static final List<String> CLEAN_STOP = Collections.singletonList("org.junit");
 
     /**
      * Gets the most specific information attached to a node.
@@ -781,7 +822,7 @@ public class JexlException extends RuntimeException {
         final JexlInfo info = node != null ? detailedInfo(node, node.jexlInfo()) : null;
         final StringBuilder msg = new StringBuilder();
         if (info != null) {
-            msg.append(info.toString());
+            msg.append(info);
         } else {
             msg.append("?:");
         }
@@ -803,7 +844,7 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Merge the node info and the cause info to obtain the best possible location.
+     * Merge the node info and the cause info to get the best possible location.
      *
      * @param info  the node
      * @param cause the cause
@@ -820,7 +861,7 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Generates a message for a unsolvable method error.
+     * Generates a message for an unsolvable method error.
      *
      * @param node the node where the error occurred
      * @param method the method name
@@ -833,7 +874,7 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Generates a message for a unsolvable method error.
+     * Generates a message for an unsolvable method error.
      *
      * @param node the node where the error occurred
      * @param method the method name
@@ -929,7 +970,7 @@ public class JexlException extends RuntimeException {
      * @param fromc the beginning column
      * @param tol the ending line
      * @param toc the ending column
-     * @return the source with the (begin) to (to) zone removed
+     * @return the source with the zone from (from) to (to) removed
      */
     public static String sliceSource(final String src, final int froml, final int fromc, final int tol, final int toc) {
         final BufferedReader reader = new BufferedReader(new StringReader(src));
@@ -1073,7 +1114,7 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Cleans a JexlException from any org.apache.commons.jexl3.internal stack trace element.
+     * Cleans a JexlException from cluttering stack trace elements.
      *
      * @return this exception
      */
@@ -1082,7 +1123,7 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Accesses detailed message.
+     * Accesses the detailed message.
      *
      * @return the message
      */
@@ -1093,9 +1134,9 @@ public class JexlException extends RuntimeException {
     }
 
     /**
-     * Gets the exception specific detail
+     * Gets the exception-specific detail.
      *
-     * @return this exception specific detail
+     * @return this exception-specific detail
      * @since 3.2
      */
     public final String getDetail() {
@@ -1130,7 +1171,7 @@ public class JexlException extends RuntimeException {
     public String getMessage() {
         final StringBuilder msg = new StringBuilder();
         if (info != null) {
-            msg.append(info.toString());
+            msg.append(info);
         } else {
             msg.append("?:");
         }

--- a/src/main/java/org/apache/commons/jexl3/JexlOperator.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlOperator.java
@@ -35,10 +35,10 @@ import java.util.function.Consumer;
  * <li>Operator methods should be public</li>
  * <li>Operators return type should be respected when primitive (int, boolean,...)</li>
  * <li>Operators may be overloaded multiple times with different signatures</li>
- * <li>Operators may return JexlEngine.TRY_AGAIN to fallback on default JEXL implementation</li>
+ * <li>Operators may return JexlEngine.TRY_FAIL to fall back on default JEXL implementation</li>
  * </ul>
  *
- * For side effect operators, operators that modify the left-hand size value (+=, -=, etc.), the user implemented
+ * For side effect operators, operators that modify the left-hand size value (+=, -=, etc.), the user-implemented
  * overload methods may return:
  * <ul>
  *     <li>JexlEngine.TRY_FAIL to let the default fallback behavior be executed.</li>

--- a/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.apache.commons.jexl3.JexlArithmetic;
 import org.apache.commons.jexl3.JexlContext;
@@ -1314,12 +1315,10 @@ public class Interpreter extends InterpreterBase {
 
     @Override
     protected Object visit(final ASTEmptyFunction node, final Object data) {
-        try {
-            final Object value = node.jjtGetChild(0).jjtAccept(this, data);
-            return operators.empty(node, value);
-        } catch (final JexlException xany) {
-            return true;
-        }
+        final JexlNode arg = node.jjtGetChild(0);
+        final Supplier<Object> eval = () -> arg.jjtAccept(this, data);
+        Object value = arithmetic.evaluate(logger, eval);
+        return value == eval ? true : operators.empty(node, value);
     }
 
     @Override
@@ -2008,12 +2007,10 @@ public class Interpreter extends InterpreterBase {
 
     @Override
     protected Object visit(final ASTSizeFunction node, final Object data) {
-        try {
-            final Object val = node.jjtGetChild(0).jjtAccept(this, data);
-            return operators.size(node, val);
-        } catch (final JexlException xany) {
-            return 0;
-        }
+        final JexlNode arg = node.jjtGetChild(0);
+        final Supplier<Object> eval = () -> arg.jjtAccept(this, data);
+        Object value = arithmetic.evaluate(logger, eval);
+        return value == eval ? 0 : operators.size(node, value);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Interpreter.java
@@ -1318,7 +1318,7 @@ public class Interpreter extends InterpreterBase {
         final JexlNode arg = node.jjtGetChild(0);
         final Supplier<Object> eval = () -> arg.jjtAccept(this, data);
         Object value = arithmetic.evaluate(logger, eval);
-        return value == eval ? true : operators.empty(node, value);
+        return value == JexlEngine.TRY_FAILED ? true : operators.empty(node, value);
     }
 
     @Override
@@ -2010,7 +2010,7 @@ public class Interpreter extends InterpreterBase {
         final JexlNode arg = node.jjtGetChild(0);
         final Supplier<Object> eval = () -> arg.jjtAccept(this, data);
         Object value = arithmetic.evaluate(logger, eval);
-        return value == eval ? 0 : operators.size(node, value);
+        return value == JexlEngine.TRY_FAILED ? 0 : operators.size(node, value);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/jexl3/Issues400Test.java
+++ b/src/test/java/org/apache/commons/jexl3/Issues400Test.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,7 +45,6 @@ import java.util.function.Function;
 
 import org.apache.commons.jexl3.internal.Debugger;
 import org.apache.commons.jexl3.internal.Engine32;
-import org.apache.commons.jexl3.internal.Operator;
 import org.apache.commons.jexl3.internal.Scope;
 import org.apache.commons.jexl3.internal.TemplateEngine;
 import org.apache.commons.jexl3.introspection.JexlPermissions;
@@ -55,7 +53,6 @@ import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.JexlScriptParser;
 import org.apache.commons.jexl3.parser.Parser;
 import org.apache.commons.jexl3.parser.StringProvider;
-import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/apache/commons/jexl3/Issues400Test.java
+++ b/src/test/java/org/apache/commons/jexl3/Issues400Test.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import java.util.function.Function;
 
 import org.apache.commons.jexl3.internal.Debugger;
 import org.apache.commons.jexl3.internal.Engine32;
+import org.apache.commons.jexl3.internal.Operator;
 import org.apache.commons.jexl3.internal.Scope;
 import org.apache.commons.jexl3.internal.TemplateEngine;
 import org.apache.commons.jexl3.introspection.JexlPermissions;
@@ -53,6 +55,7 @@ import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.JexlScriptParser;
 import org.apache.commons.jexl3.parser.Parser;
 import org.apache.commons.jexl3.parser.StringProvider;
+import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -1181,6 +1184,21 @@ public class Issues400Test {
         final StringWriter writer = new StringWriter();
         template.evaluate(null, writer);
         assertEquals("42", writer.toString());
+    }
+
+
+    @Test
+    void test459() {
+        CaptureLog capture = new CaptureLog("test459");
+        final JexlBuilder builder = new JexlBuilder().logger(capture).safe(true).strict(false).silent(true);
+        final JexlEngine jexl = builder.create();
+        String expr = "empty('aaa'.substring(400,500))";
+        JexlScript script = jexl.createScript(expr);
+        Object result = script.execute(null);
+        assertEquals(true, result);
+        List<String> errors = capture.getCapturedMessages();
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("substring"));
     }
 
 }

--- a/src/test/java/org/apache/commons/jexl3/Issues400Test.java
+++ b/src/test/java/org/apache/commons/jexl3/Issues400Test.java
@@ -1194,8 +1194,8 @@ public class Issues400Test {
         Object result = script.execute(null);
         assertEquals(true, result);
         List<String> errors = capture.getCapturedMessages();
-        assertEquals(1, errors.size());
-        assertTrue(errors.get(0).contains("substring"));
+        assertEquals(1, capture.count("warn"));
+        assertTrue(errors.stream().anyMatch(error -> error.contains("substring")));
     }
 
 }

--- a/src/test/java/org/apache/commons/jexl3/Issues400Test.java
+++ b/src/test/java/org/apache/commons/jexl3/Issues400Test.java
@@ -1189,13 +1189,24 @@ public class Issues400Test {
         CaptureLog capture = new CaptureLog("test459");
         final JexlBuilder builder = new JexlBuilder().logger(capture).safe(true).strict(false).silent(true);
         final JexlEngine jexl = builder.create();
-        String expr = "empty('aaa'.substring(400,500))";
-        JexlScript script = jexl.createScript(expr);
-        Object result = script.execute(null);
-        assertEquals(true, result);
-        List<String> errors = capture.getCapturedMessages();
-        assertEquals(1, capture.count("warn"));
-        assertTrue(errors.stream().anyMatch(error -> error.contains("substring")));
+        Object[] expected = { true, true, 0, 0 };
+        String[] expressions = {
+          "empty('aaa'.substring(400,500))",
+          "empty('aaa'.substring(-1, 2))",
+          "size('aaa'.substring(400,500))",
+          "size('aaa'.substring(-1, 2))",
+        };
+        for (int i = 0; i < expressions.length; ++i) {
+            String expr = expressions[i];
+            Object control = expected[i];
+            capture.clear();
+            JexlScript script = jexl.createScript(expr);
+            Object result = script.execute(null);
+            assertEquals(control, result);
+            List<String> errors = capture.getCapturedMessages();
+            assertEquals(1, capture.count("warn"));
+            assertTrue(errors.stream().anyMatch(error -> error.contains("substring")));
+        }
     }
 
 }


### PR DESCRIPTION
Added JexlArithmetic.evaluate() method to handle Supplier argument evaluation with proper exception logging
Previously, the empty() and size() operators would silently swallow JexlExceptions with no diagnostic information
Now logs warnings when exceptions occur during argument evaluation, improving debuggability
The method is public and overridable to allow custom exception handling strategies