### PR TITLE
[JEXL-411] Allow optional leading zeroes in floating point literals

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -29,7 +29,10 @@
     <body>
         <release version="3.7.1" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
             <!-- ADD -->
+            <action dev="henrib" type="add" issue="JEXL-467">IntelliJ and VSCode editors (TextMate bundle) support for JEXL.</action>
             <!-- FIX -->
+            <action dev="henrib" type="fix" issue="JEXL-466">IllegalStateException parsing a template with string interpolation.</action>
+            <action dev="NikRom5531" due-to="Felix Rudolphi" type="fix" issue="JEXL-411">Leading zeroes in floating point numbers should be optional.</action>
             <action dev="ggregory" type="fix" due-to="Gary Gregory">Pick up commons.jacoco.version from the parent POM.</action>
             <action dev="ggregory" type="fix" due-to="Gary Gregory">Add messages when throwing NullPointerException.</action>
             <!-- UPDATE -->

--- a/src/main/java/org/apache/commons/jexl3/parser/JexlParser.java
+++ b/src/main/java/org/apache/commons/jexl3/parser/JexlParser.java
@@ -932,6 +932,29 @@ public abstract class JexlParser extends StringParser implements JexlScriptParse
         return !getFeatures().supportsAmbiguousStatement();
     }
 
+
+    /**
+     * Checks whether a token image is composed only of decimal digits.
+     * <p>Used to recognize a floating point literal with an omitted leading
+     * zero (e.g. {@code .1}) that is tokenized as {@code DOT DOT_IDENTIFIER}.</p>
+     *
+     * @param image the token image
+     * @return true if every character is a decimal digit
+     */
+    protected boolean isAllDigits(final String image) {
+        int len = image != null ? image.length() : 0;
+        if (len == 0) {
+            return false;
+        }
+        for (int i = 0; i < len; ++i) {
+            final char c = image.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Called by parser at end of node construction.
      * <p>

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -107,6 +107,27 @@ public final class Parser extends JexlParser
             jjtree.reset();
         }
     }
+
+    /**
+     * Checks whether a token image is composed only of decimal digits.
+     * <p>Used to recognize a floating point literal with an omitted leading
+     * zero (e.g. {@code .1}) that is tokenized as {@code DOT DOT_IDENTIFIER}.</p>
+     *
+     * @param image the token image
+     * @return true if every character is a decimal digit
+     */
+    private static boolean isAllDigits(final String image) {
+        if (image.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < image.length(); i++) {
+            final char c = image.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 
 PARSER_END(Parser)
@@ -1064,6 +1085,9 @@ void FloatLiteral() #NumberLiteral:
 {
   t=<FLOAT_LITERAL>
   { jjtThis.setReal(t.image); }
+  |
+  <DOT> t=<DOT_IDENTIFIER>
+  { if (!isAllDigits(t.image)) { throwParsingException(t); } jjtThis.setReal("." + t.image); }
 }
 
 void StringLiteral() :

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -107,27 +107,6 @@ public final class Parser extends JexlParser
             jjtree.reset();
         }
     }
-
-    /**
-     * Checks whether a token image is composed only of decimal digits.
-     * <p>Used to recognize a floating point literal with an omitted leading
-     * zero (e.g. {@code .1}) that is tokenized as {@code DOT DOT_IDENTIFIER}.</p>
-     *
-     * @param image the token image
-     * @return true if every character is a decimal digit
-     */
-    private static boolean isAllDigits(final String image) {
-        if (image.isEmpty()) {
-            return false;
-        }
-        for (int i = 0; i < image.length(); i++) {
-            final char c = image.charAt(i);
-            if (c < '0' || c > '9') {
-                return false;
-            }
-        }
-        return true;
-    }
 }
 
 PARSER_END(Parser)

--- a/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
+++ b/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
@@ -2362,11 +2362,13 @@ class ArithmeticTest extends JexlTestCase {
         assertEquals(-1.4d, jexl.createExpression("-.5+-.9").evaluate(jc));
         // unary handling
         assertEquals(-0.1d, jexl.createExpression("-.1").evaluate(jc));
+        assertEquals(0.1d, jexl.createExpression("+.1").evaluate(jc));
         // property / index access via a dot must keep working (not parsed as a float)
         final List<Object> array = new java.util.ArrayList<>();
         array.add("zero");
         array.add("one");
         jc.set("array", array);
+        assertEquals("zero", jexl.createExpression("array.0").evaluate(jc));
         assertEquals("one", jexl.createExpression("array.1").evaluate(jc));
     }
 }

--- a/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
+++ b/src/test/java/org/apache/commons/jexl3/ArithmeticTest.java
@@ -2341,4 +2341,32 @@ class ArithmeticTest extends JexlTestCase {
             this.options = options;
         }
     }
+
+    @Test void testLeadingDotFloatLiteral() {
+        final JexlEngine jexl = new JexlBuilder().create();
+        final JexlContext jc = new MapContext();
+        // the exact case from JEXL-411
+        assertEquals(2.2d, jexl.createExpression("(1+.1)*2").evaluate(jc));
+        // the regression case that already worked
+        assertEquals(2.2d, jexl.createExpression("(1+0.1)*2").evaluate(jc));
+        // standalone and compound leading-dot literals
+        assertEquals(0.1d, jexl.createExpression(".1").evaluate(jc));
+        assertEquals(1.0d, jexl.createExpression(".5 + .5").evaluate(jc));
+        assertEquals(0.55d, jexl.createExpression(".55").evaluate(jc));
+        assertEquals(0.1d, jexl.createExpression("-.1 + .2").evaluate(jc));
+        assertEquals(-0.1d, jexl.createExpression(".1 + -.2").evaluate(jc));
+        assertEquals(0.1d, jexl.createExpression("-.1+.2").evaluate(jc));
+        assertEquals(-0.1d, jexl.createExpression(".1+-.2").evaluate(jc));
+        assertEquals(1.4d, jexl.createExpression(".5 - -.9").evaluate(jc));
+        assertEquals(0.4d, jexl.createExpression("-.5 - -.9").evaluate(jc));
+        assertEquals(-1.4d, jexl.createExpression("-.5+-.9").evaluate(jc));
+        // unary handling
+        assertEquals(-0.1d, jexl.createExpression("-.1").evaluate(jc));
+        // property / index access via a dot must keep working (not parsed as a float)
+        final List<Object> array = new java.util.ArrayList<>();
+        array.add("zero");
+        array.add("one");
+        jc.set("array", array);
+        assertEquals("one", jexl.createExpression("array.1").evaluate(jc));
+    }
 }


### PR DESCRIPTION
### Summary / Why
Fixing bug JEXL-411 (https://issues.apache.org/jira/browse/JEXL-411):
JEXL could not parse a floating point literal with an omitted leading
zero (e.g. ".1"), so "(1+0.1)*2" evaluated to 2.2 while "(1+.1)*2"
raised a parsing error, although ".1" is valid in Java.

### How
A leading-dot number is tokenized as "DOT DOT_IDENTIFIER", which is
identical to the postfix index access "x.3" and cannot be told apart at
the lexer level. The literal is therefore recognized in the parser, in
operand position. `FloatLiteral()` in `Parser.jjt` now also accepts
".<digits>" (only all-digit `DOT_IDENTIFIER` images, checked via a new
`isAllDigits` guard) and rebuilds the value as "." + image before
handing it to `NumberParser`. Dot-based index/property access is
parsed first by `MemberAccess`/`IdentifierAccess` and left untouched.

### Tests
`ArithmeticTest#testLeadingDotFloatLiteral`:
- "(1+.1)*2" == 2.2 (JEXL-411 reproduction)
- "(1+0.1)*2" == 2.2 (regression)
- ".1" == 0.1, "-.1" == -0.1, ".5 + .5" == 1.0, ".55" == 0.55
- unary/compound: "-.1+.2" == 0.1, ".1+-.2" == -0.1, ".5 - -.9" == 1.4
- "array.1" still resolves to index access (regression)
- The test fails on the previous grammar and passes on this one.

### Verification
- `mvn` (incl. apache-rat license check): BUILD SUCCESS
- `mvn test`: 1164 tests, 0 failures, 0 errors

### Notes
- The JIRA account was read-only, so a PR link could not be added to the
  ticket; the issue is referenced via the key in the branch, commits and
  this description.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
