### PR TITLE
[JEXL-469] Add namespaceInstantiation feature knob

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/JexlFeatures.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlFeatures.java
@@ -76,7 +76,7 @@ public final class JexlFeatures {
         "global assign/modify", "array reference", "create instance", "loop", "function",
         "method call", "set/map/array literal", "pragma", "annotation", "script", "lexical", "lexicalShade",
         "thin-arrow", "fat-arrow", "namespace pragma", "namespace identifier", "import pragma", "comparator names", "pragma anywhere",
-        "const capture", "ref capture", "ambiguous statement", "ignore template prefix"
+        "const capture", "ref capture", "ambiguous statement", "ignore template prefix", "namespace instantiation"
     };
 
     /** Registers feature ordinal. */
@@ -166,11 +166,14 @@ public final class JexlFeatures {
     @Deprecated
     public static final int STRICT_STATEMENT = 25;
 
+    /** Allow reflective auto-instantiation of a namespace functor from a class/FQCN binding. */
+    public static final int NAMESPACE_INSTANTIATE = 27;
+
     /**
      * All features.
      * Ensure this is updated if additional features are added.
      */
-    private static final long ALL_FEATURES = (1L << IGNORE_TEMPLATE_PREFIX + 1) - 1L; // MUST REMAIN PRIVATE
+    private static final long ALL_FEATURES = (1L << NAMESPACE_INSTANTIATE + 1) - 1L; // MUST REMAIN PRIVATE
 
     /**
      * The default features flag mask.
@@ -193,7 +196,8 @@ public final class JexlFeatures {
         | 1L << NS_PRAGMA
         | 1L << IMPORT_PRAGMA
         | 1L << COMPARATOR_NAMES
-        | 1L << PRAGMA_ANYWHERE;
+        | 1L << PRAGMA_ANYWHERE
+        | 1L << NAMESPACE_INSTANTIATE;
 
     /**
      * The canonical scripting (since 3.3.1) features flag mask based on the original default.
@@ -425,6 +429,26 @@ public final class JexlFeatures {
      */
     public JexlFeatures referenceCapture(final boolean flag) {
         setFeature(REF_CAPTURE, flag);
+        return this;
+    }
+
+    /**
+     * Sets whether a namespace bound to a class or fully-qualified class name may be
+     * reflectively auto-instantiated into a functor.
+     * <p>
+     * When enabled (the default), a namespace declared as a {@link Class} or class-name
+     * {@link String} is instantiated - through a constructor, optionally receiving the
+     * context - the first time it is used, allowing instance (non-static) namespace methods.
+     * When disabled, no constructor is invoked: only static methods of the bound class are
+     * reachable and explicit host-supplied functors are still honored.
+     * </p>
+     *
+     * @param flag true to enable, false to disable
+     * @return this features instance
+     * @since 3.6
+     */
+    public JexlFeatures namespaceInstantiation(final boolean flag) {
+        setFeature(NAMESPACE_INSTANTIATE, flag);
         return this;
     }
 
@@ -935,6 +959,17 @@ public final class JexlFeatures {
      */
     public boolean supportsReferenceCapture() {
         return getFeature(REF_CAPTURE);
+    }
+
+    /**
+     * Does the engine allow reflective auto-instantiation of a namespace functor
+     * from a class or class-name binding?
+     *
+     * @return true if namespace auto-instantiation is allowed, false otherwise
+     * @since 3.6
+     */
+    public boolean supportsNamespaceInstantiation() {
+        return getFeature(NAMESPACE_INSTANTIATE);
     }
 
     /**

--- a/src/main/java/org/apache/commons/jexl3/JexlOptions.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlOptions.java
@@ -47,6 +47,9 @@ import org.apache.commons.jexl3.internal.Engine;
  */
 public final class JexlOptions {
 
+    /** The namespace auto-instantiation flag. */
+    private static final int NAMESPACE_INSTANTIATE = 11;
+
     /** The boolean logical flag. */
     private static final int BOOLEAN_LOGICAL = 10;
 
@@ -84,11 +87,12 @@ public final class JexlOptions {
     private static final String[] NAMES = {
         "cancellable", "strict", "silent", "safe", "lexical", "antish",
         "lexicalShade", "sharedInstance", "constCapture", "strictInterpolation",
-        "booleanShortCircuit"
+        "booleanShortCircuit", "namespaceInstantiation"
     };
 
     /** Default mask .*/
-    private static int DEFAULT = 1 /*<< CANCELLABLE*/ | 1 << STRICT | 1 << ANTISH | 1 << SAFE;
+    private static int DEFAULT = 1 /*<< CANCELLABLE*/ | 1 << STRICT | 1 << ANTISH | 1 << SAFE
+        | 1 << NAMESPACE_INSTANTIATE;
 
     /**
      * Checks the value of a flag in the mask.
@@ -278,6 +282,17 @@ public final class JexlOptions {
     }
 
     /**
+     * Is reflective auto-instantiation of a namespace functor from a class/class-name
+     * binding allowed?
+     *
+     * @return true if namespace auto-instantiation is allowed, false otherwise
+     * @since 3.6
+     */
+    public boolean isNamespaceInstantiation() {
+        return isSet(NAMESPACE_INSTANTIATE, flags);
+    }
+
+    /**
      * Checks whether runtime variable scope is lexical.
      * <p>If true, lexical scope applies to local variables and parameters.
      * Redefining a variable in the same lexical unit will generate errors.
@@ -431,6 +446,17 @@ public final class JexlOptions {
      */
     public void setConstCapture(final boolean flag) {
         flags = set(CONST_CAPTURE, flags, flag);
+    }
+
+    /**
+     * Sets whether a namespace bound to a class or class-name may be reflectively
+     * auto-instantiated into a functor.
+     *
+     * @param flag true to enable, false to disable
+     * @since 3.6
+     */
+    public void setNamespaceInstantiation(final boolean flag) {
+        flags = set(NAMESPACE_INSTANTIATE, flags, flag);
     }
 
     /**

--- a/src/main/java/org/apache/commons/jexl3/internal/Engine.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/Engine.java
@@ -404,6 +404,10 @@ public class Engine extends JexlEngine implements JexlUberspect.ConstantResolver
         }
         this.expressionFeatures = new JexlFeatures(features).script(false).namespaceTest(nsTest);
         this.scriptFeatures = new JexlFeatures(features).script(true).namespaceTest(nsTest);
+        // a parse-time feature that gates a run-time behavior: bridge it into the base options
+        if (!features.supportsNamespaceInstantiation()) {
+            options.setNamespaceInstantiation(false);
+        }
         this.charset = conf.charset();
         // caching:
         final IntFunction<JexlCache<?, ?>> factory = conf.cacheFactory();
@@ -532,6 +536,10 @@ public class Engine extends JexlEngine implements JexlUberspect.ConstantResolver
         if (script != null) {
            // process script pragmas if any
            processPragmas(script, context, opts);
+        }
+        // reapply after pragmas: a feature restriction must not be overridable by a pragma
+        if (opts != options && !scriptFeatures.supportsNamespaceInstantiation()) {
+            opts.setNamespaceInstantiation(false);
         }
         return opts;
     }

--- a/src/main/java/org/apache/commons/jexl3/internal/InterpreterBase.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/InterpreterBase.java
@@ -906,8 +906,10 @@ public abstract class InterpreterBase extends ParserVisitor {
             if (cached instanceof Class<?>) {
                 return cached;
             }
+            // whether reflective auto-instantiation of a functor is allowed for this namespace
+            final boolean instantiate = options.isNamespaceInstantiation();
             // attempt to reuse last cached constructor
-            if (cached instanceof JexlContext.NamespaceFunctor) {
+            if (instantiate && cached instanceof JexlContext.NamespaceFunctor) {
                 final Object eval = ((JexlContext.NamespaceFunctor) cached).createFunctor(context);
                 if (JexlEngine.TRY_FAILED != eval) {
                     functor = eval;
@@ -916,7 +918,7 @@ public abstract class InterpreterBase extends ParserVisitor {
             }
             if (functor == null) {
                 // find a constructor with that context as argument or without
-                for (int tried = 0; tried < 2; ++tried) {
+                for (int tried = 0; instantiate && tried < 2; ++tried) {
                     final boolean withContext = tried == 0;
                     final JexlMethod ctor = withContext
                             ? uberspect.getConstructor(namespace, context)
@@ -947,18 +949,21 @@ public abstract class InterpreterBase extends ParserVisitor {
                 }
                 // did not, will not create a functor instance; use a class, namespace of static methods
                 if (functor == null) {
-                    try {
-                        // try to find a class with that name
-                        if (namespace instanceof String) {
-                            namespace = uberspect.getClassLoader().loadClass((String) namespace);
+                    // try to find a class with that name; getClassByName is permission-aware and returns
+                    // null when the class is denied by permissions or cannot be located (f047).
+                    if (namespace instanceof String) {
+                        final Class<?> clazz = uberspect.getClassByName((String) namespace);
+                        if (clazz == null) {
+                            throw new JexlException(node, "no such class namespace " + prefix, null);
                         }
-                        // we know it's a class in all cases (see *1)
-                        if (cacheable) {
-                            nsNode.jjtSetValue(namespace);
-                        }
-                    } catch (final ClassNotFoundException e) {
-                        // not a class
-                        throw new JexlException(node, "no such class namespace " + prefix, e);
+                        namespace = clazz;
+                    }
+                    // only cache the Class<?> when instantiation was attempted (and no ctor was found);
+                    // when instantiation is disabled we skip the ctor search, so the cache entry would be
+                    // ambiguous: a later execution with instantiation enabled would hit the Class<?> fast-path
+                    // and never try the constructor.
+                    if (cacheable && instantiate) {
+                        nsNode.jjtSetValue(namespace);
                     }
                 }
             }

--- a/src/test/java/org/apache/commons/jexl3/FeaturesTest.java
+++ b/src/test/java/org/apache/commons/jexl3/FeaturesTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.jexl3;
 
-import static org.apache.commons.jexl3.JexlFeatures.IGNORE_TEMPLATE_PREFIX;
+import static org.apache.commons.jexl3.JexlFeatures.NAMESPACE_INSTANTIATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -72,8 +72,8 @@ class FeaturesTest extends JexlTestCase {
     @Test
     void test410a() {
         final long x = JexlFeatures.createAll().getFlags();
-        assertEquals(IGNORE_TEMPLATE_PREFIX + 1, Long.bitCount(x));
-        assertTrue((x & 1L << IGNORE_TEMPLATE_PREFIX) != 0);
+        assertEquals(NAMESPACE_INSTANTIATE + 1, Long.bitCount(x));
+        assertTrue((x & 1L << NAMESPACE_INSTANTIATE) != 0);
 
         final JexlFeatures all = JexlFeatures.createAll();
         final JexlEngine jexl = new JexlBuilder().features(all).create();

--- a/src/test/java/org/apache/commons/jexl3/NamespaceInstantiationTest.java
+++ b/src/test/java/org/apache/commons/jexl3/NamespaceInstantiationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.jexl3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.jexl3.annotations.NoJexl;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the {@link JexlFeatures#namespaceInstantiation(boolean)} knob that gates the reflective
+ * auto-instantiation of a namespace functor from a class or class-name binding.
+ */
+class NamespaceInstantiationTest extends JexlTestCase {
+
+    public NamespaceInstantiationTest() {
+        super("NamespaceInstantiationTest");
+    }
+
+    /** Counts constructor invocations to prove (non-)instantiation. */
+    static final AtomicInteger CTOR = new AtomicInteger();
+
+    /** A namespace whose only method is an instance method; usable only if auto-instantiated. */
+    public static class InstanceNs {
+        private final int base;
+        public InstanceNs(final JexlContext ctxt) {
+            CTOR.incrementAndGet();
+            final Object n = ctxt.get("BASE");
+            base = n instanceof Number ? ((Number) n).intValue() : 0;
+        }
+        public int callIt(final int n) {
+            return n + base;
+        }
+    }
+
+    /** A namespace with a usable static method; no instantiation required. */
+    public static class StaticNs {
+        private StaticNs() { }
+        public static int callIt(final int n) {
+            return n + 19;
+        }
+    }
+
+    /** A namespace hidden from JEXL via {@code @NoJexl}; must not be reachable as a namespace. */
+    @NoJexl
+    public static class HiddenNs {
+        public static int callIt(final int n) {
+            return n + 1;
+        }
+    }
+
+    @Test
+    void testFeatureDefaultsOn() {
+        assertTrue(new JexlFeatures().supportsNamespaceInstantiation());
+        assertTrue(new JexlFeatures().namespaceInstantiation(false).namespaceInstantiation(true)
+                .supportsNamespaceInstantiation());
+        assertFalse(new JexlFeatures().namespaceInstantiation(false).supportsNamespaceInstantiation());
+    }
+
+    @Test
+    void testInstantiationEnabled() {
+        CTOR.set(0);
+        final JexlContext ctxt = new MapContext();
+        ctxt.set("BASE", 19);
+        // class-bound namespace auto-instantiates (default feature on) and the instance method runs
+        final JexlEngine jexl = new JexlBuilder().strict(true).silent(false)
+                .features(new JexlFeatures().namespaceInstantiation(true))
+                .namespaces(Collections.singletonMap("nsns", InstanceNs.class)).create();
+        final JexlScript s = jexl.createScript("x -> { nsns:callIt(x); }");
+        assertEquals(42, s.execute(ctxt, 23));
+        assertEquals(1, CTOR.get());
+    }
+
+    @Test
+    void testInstantiationDisabledBlocksInstanceNs() {
+        CTOR.set(0);
+        final JexlContext ctxt = new MapContext();
+        ctxt.set("BASE", 19);
+        final JexlEngine jexl = new JexlBuilder().strict(true).silent(false)
+                .features(new JexlFeatures().namespaceInstantiation(false))
+                .namespaces(Collections.singletonMap("nsns", InstanceNs.class)).create();
+        final JexlScript s = jexl.createScript("x -> { nsns:callIt(x); }");
+        // with instantiation disabled, the class is treated as a static-method namespace only;
+        // InstanceNs has no static callIt(int), so resolution fails and no constructor is invoked
+        assertThrows(JexlException.class, () -> s.execute(ctxt, 23));
+        assertEquals(0, CTOR.get());
+    }
+
+    @Test
+    void testInstantiationDisabledKeepsStaticNs() {
+        final JexlEngine jexl = new JexlBuilder().strict(true).silent(false)
+                .features(new JexlFeatures().namespaceInstantiation(false))
+                .namespaces(Collections.singletonMap("sns", StaticNs.class)).create();
+        final JexlScript s = jexl.createScript("x -> { sns:callIt(x); }");
+        assertEquals(42, s.execute(new MapContext(), 23));
+    }
+
+    @Test
+    void testInstantiationDisabledKeepsStaticNsByName() {
+        final JexlEngine jexl = new JexlBuilder().strict(true).silent(false)
+                .features(new JexlFeatures().namespaceInstantiation(false))
+                .namespaces(Collections.singletonMap("sns", StaticNs.class.getName())).create();
+        final JexlScript s = jexl.createScript("x -> { sns:callIt(x); }");
+        assertEquals(42, s.execute(new MapContext(), 23));
+    }
+
+    @Test
+    void testStringNamespaceDeniedClass() {
+        // a namespace bound to a class-name that resolves to a permission-denied class must throw
+        // when used for static methods, rather than silently loading the class (f047)
+        final JexlEngine jexl = new JexlBuilder().strict(true).silent(false)
+                .namespaces(Collections.singletonMap("h", HiddenNs.class.getName())).create();
+        final JexlScript script = jexl.createScript("h:callIt(41)");
+        final JexlException xany = assertThrows(JexlException.class, () -> script.execute(new MapContext()));
+        assertTrue(xany.getMessage().contains("class namespace") || xany.getMessage().contains("HiddenNs"),
+                xany.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `JexlFeatures.namespaceInstantiation(boolean)` to control whether a namespace bound to a `Class` or fully-qualified class name string is reflectively auto-instantiated into a functor. Default `true` preserves backward compatibility.
- When disabled, only static methods of the bound class are reachable; no constructor is invoked.
- String namespaces resolved to a class for static methods now go through the permission-aware `JexlUberspect.getClassByName` instead of loading the class directly.

Closes JEXL-469.

## Test plan
- [ ] `NamespaceInstantiationTest` covers enabled/disabled behaviour and static-only access
- [ ] `mvn test` passes
- [ ] `mvn` (full build including checkstyle) passes